### PR TITLE
add support for `https://youtu.be` url

### DIFF
--- a/src/platforms/_httpx.py
+++ b/src/platforms/_httpx.py
@@ -5,7 +5,7 @@
 #
 
 import asyncio
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 
 import aiofiles
 import httpx


### PR DESCRIPTION
## Summary by Sourcery

Enhance YouTube URL support by expanding the URL recognition pattern and improving URL handling for different YouTube link formats

Bug Fixes:
- Add fallback search mechanism when direct URL metadata retrieval fails
- Handle youtu.be short links by converting them to standard YouTube watch URLs

Enhancements:
- Improve YouTube URL parsing to support additional URL formats including youtu.be short links
- Extend URL matching regex to handle more YouTube video link variations