### PR TITLE
add close button

### DIFF
--- a/src/modules/funcs.py
+++ b/src/modules/funcs.py
@@ -456,7 +456,13 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery) -> No
         # Check admin permissions for control actions
         def requires_admin(cb_data: str) -> bool:
             """Check if the action requires admin privileges."""
-            return cb_data in {"play_skip", "play_stop", "play_pause", "play_resume"}
+            return cb_data in {
+                "play_skip",
+                "play_stop",
+                "play_pause",
+                "play_resume",
+                "play_close",
+            }
 
         if requires_admin(data) and not await is_admin(chat_id, user_id):
             await message.answer(
@@ -530,7 +536,15 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery) -> No
                 await send_response(
                     "⚠️ Error resuming the stream. Please try again.", alert=True
                 )
-
+        elif data == "play_close":
+            _delete = await c.deleteMessages(chat_id, [message.message_id], revoke=True)
+            if isinstance(_delete, types.Error):
+                await message.answer(
+                    f"Failed to close {_delete.message}", show_alert=True
+                )
+                return
+            await message.answer(f"Closed !", show_alert=True)
+            return
         elif data.startswith("play_c_"):
             await _handle_play_c_data(data, message, chat_id, user_id, user_name, c)
             return

--- a/src/modules/utils/buttons.py
+++ b/src/modules/utils/buttons.py
@@ -23,6 +23,12 @@ PlayButton = types.ReplyMarkupInlineKeyboard(
                 text="🔁", type=types.InlineKeyboardButtonTypeCallback(b"play_resume")
             ),
         ],
+        [
+            types.InlineKeyboardButton(
+                text="❌ Close",
+                type=types.InlineKeyboardButtonTypeCallback(b"play_close"),
+            )
+        ],
     ]
 )
 
@@ -38,6 +44,12 @@ PauseButton = types.ReplyMarkupInlineKeyboard(
             types.InlineKeyboardButton(
                 text="🔁", type=types.InlineKeyboardButtonTypeCallback(b"play_resume")
             ),
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="❌ Close",
+                type=types.InlineKeyboardButtonTypeCallback(b"play_close"),
+            )
         ],
     ]
 )
@@ -55,6 +67,12 @@ ResumeButton = types.ReplyMarkupInlineKeyboard(
                 text="⏸️", type=types.InlineKeyboardButtonTypeCallback(b"play_pause")
             ),
         ],
+        [
+            types.InlineKeyboardButton(
+                text="❌ Close",
+                type=types.InlineKeyboardButtonTypeCallback(b"play_close"),
+            )
+        ],
     ]
 )
 
@@ -69,7 +87,13 @@ SupportButton = types.ReplyMarkupInlineKeyboard(
                 text="✨ Group",
                 type=types.InlineKeyboardButtonTypeUrl(config.SUPPORT_GROUP),
             ),
-        ]
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="❌ Close",
+                type=types.InlineKeyboardButtonTypeCallback(b"play_close"),
+            )
+        ],
     ]
 )
 


### PR DESCRIPTION
## Summary by Sourcery

Add a close button to various inline keyboards in the music player interface

New Features:
- Introduce a new 'Close' button (❌) to music player inline keyboards that allows users to dismiss the current message

Enhancements:
- Extend the callback handler to support a new 'play_close' action
- Add admin permission check for the close button action