### PR TITLE
add /logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .env
 /cookies
 /tgmusicbot.egg-info
+*.log

--- a/src/helpers/_pytgcalls.py
+++ b/src/helpers/_pytgcalls.py
@@ -195,6 +195,7 @@ class Call:
             media_path=file_path,
             audio_parameters=AudioQuality.HIGH if video else AudioQuality.STUDIO,
             video_parameters=VideoQuality.FHD_1080p if video else VideoQuality.SD_360p,
+            audio_flags=MediaStream.Flags.REQUIRED,
             video_flags=(
                 MediaStream.Flags.AUTO_DETECT if video else MediaStream.Flags.IGNORE
             ),

--- a/src/helpers/_pytgcalls.py
+++ b/src/helpers/_pytgcalls.py
@@ -212,13 +212,6 @@ class Call:
                 )
 
             return types.Ok()
-
-        except errors.ChatAdminRequired:
-            return types.Error(
-                code=403,
-                message="No active voice chat found.\n\n"
-                "Please start a voice chat and try again.",
-            )
         except (exceptions.NoActiveGroupCall, ConnectionNotFound):
             return types.Error(
                 code=404,
@@ -231,6 +224,9 @@ class Call:
                 code=502,
                 message="Telegram server issues detected. Please try again later.",
             )
+        except exceptions.NoAudioSourceFound as e:
+            LOGGER.error("Audio source not found in chat %s: %s", chat_id, str(e))
+            return types.Error(code=404, message="Audio source not found.")
         except errors.RPCError as e:
             LOGGER.error("Playback failed in chat %s: %s", chat_id, str(e))
             return types.Error(code=e.CODE or 500, message=f"Playback error: {str(e)}")

--- a/src/helpers/_pytgcalls.py
+++ b/src/helpers/_pytgcalls.py
@@ -77,7 +77,7 @@ class Call:
             LOGGER.info("Set assistant for %s to %s", chat_id, new_client)
             return new_client
 
-    async def _group_assistant(self, chat_id: int) -> Union[PyTgCalls, types.Error]:
+    async def group_assistant(self, chat_id: int) -> Union[PyTgCalls, types.Error]:
         client_name = await self._get_client_name(chat_id)
         if isinstance(client_name, types.Error):
             return client_name
@@ -93,7 +93,7 @@ class Call:
         Returns:
             PyroClient instance or types.Error if unavailable
         """
-        client = await self._group_assistant(chat_id)
+        client = await self.group_assistant(chat_id)
         if isinstance(client, types.Error):
             return client
 
@@ -180,7 +180,7 @@ class Call:
             "Playing media for chat %s: %s (video=%s)", chat_id, file_path, video
         )
 
-        client = await self._group_assistant(chat_id)
+        client = await self.group_assistant(chat_id)
         if isinstance(client, types.Error):
             return client
 
@@ -448,7 +448,7 @@ class Call:
         """
         LOGGER.info("Ending playback for chat %s", chat_id)
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -551,7 +551,7 @@ class Call:
             None on success or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -576,7 +576,7 @@ class Call:
             types.Ok on success or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -596,7 +596,7 @@ class Call:
             types.Ok on success or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -618,7 +618,7 @@ class Call:
             types.Ok on success or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -640,7 +640,7 @@ class Call:
             types.Ok on success or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -660,7 +660,7 @@ class Call:
             Current position in seconds or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -686,7 +686,7 @@ class Call:
             List of participants or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 
@@ -716,7 +716,7 @@ class Call:
             Tuple of (ping, cpu_usage) or types.Error on failure
         """
         try:
-            client = await self._group_assistant(chat_id)
+            client = await self.group_assistant(chat_id)
             if isinstance(client, types.Error):
                 return client
 

--- a/src/logger.py
+++ b/src/logger.py
@@ -20,8 +20,8 @@ logging.getLogger("pyrogram").setLevel(logging.WARNING)
 logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
 # logging.getLogger('pytgcalls').setLevel(logging.DEBUG)
-logging.getLogger('ffmpeg').setLevel(logging.DEBUG)
-logging.getLogger('ntgcalls').setLevel(logging.DEBUG)
-logging.getLogger('webrtc').setLevel(logging.DEBUG)
+# logging.getLogger('ffmpeg').setLevel(logging.DEBUG)
+# logging.getLogger('ntgcalls').setLevel(logging.DEBUG)
+# logging.getLogger('webrtc').setLevel(logging.DEBUG)
 
 LOGGER = logging.getLogger("Bot")

--- a/src/logger.py
+++ b/src/logger.py
@@ -17,8 +17,8 @@ logging.getLogger("pyrogram").setLevel(logging.WARNING)
 logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
 # logging.getLogger('pytgcalls').setLevel(logging.DEBUG)
-# logging.getLogger('ffmpeg').setLevel(logging.DEBUG)
-# logging.getLogger('ntgcalls').setLevel(logging.DEBUG)
-# logging.getLogger('webrtc').setLevel(logging.DEBUG)
+logging.getLogger('ffmpeg').setLevel(logging.DEBUG)
+logging.getLogger('ntgcalls').setLevel(logging.DEBUG)
+logging.getLogger('webrtc').setLevel(logging.DEBUG)
 
 LOGGER = logging.getLogger("Bot")

--- a/src/logger.py
+++ b/src/logger.py
@@ -8,7 +8,10 @@ logging.basicConfig(
     level=logging.INFO,
     format="[%(asctime)s - %(levelname)s] - %(name)s - %(filename)s:%(lineno)d - %(message)s",
     datefmt="%d-%b-%y %H:%M:%S",
-    handlers=[logging.StreamHandler()],
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler("bot.log")
+    ],
 )
 
 # Reduce logging verbosity for third-party libraries

--- a/src/modules/devs.py
+++ b/src/modules/devs.py
@@ -422,3 +422,16 @@ async def clear_all_assistants(c: Client, message: types.Message) -> None:
     if isinstance(reply, types.Error):
         c.logger.warning(reply.message)
     return
+
+@Client.on_message(filters=Filter.command("logs"))
+async def logs(c: Client, message: types.Message) -> None:
+    if message.from_id not in DEVS:
+        await del_msg(message)
+        return
+
+    reply = await message.reply_document(
+        document=types.InputFileLocal("bot.log"),
+        disable_notification=True,
+    )
+    if isinstance(reply, types.Error):
+        c.logger.warning(reply.message)

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -592,6 +592,7 @@ async def yt(_: Client, msg: types.Message) -> None:
                 link,
                 AudioQuality.HIGH,
                 VideoQuality.HD_720p,
+                audio_flags=MediaStream.Flags.REQUIRED,
                 ytdlp_parameters=f'--proxy {PROXY}',
             ),
         )

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -568,6 +568,42 @@ async def play_file(_: Client, msg: types.Message) -> None:
     return None
 
 
+@Client.on_message(filters=Filter.command(["yt"]))
+async def yt(_: Client, msg: types.Message) -> None:
+    """JUST FOR TESTING"""
+    chat_id =  msg.chat_id
+    user_id = msg.from_id
+    if user_id != OWNER_ID:
+        return None
+
+    link = extract_argument(msg.text)
+    if not link:
+        return None
+
+    try:
+        call_py = await call.group_assistant(chat_id)
+        if isinstance(call_py, types.Error):
+            await msg.reply_text(str(call_py))
+            return None
+
+        await call_py.play(
+            chat_id,
+            MediaStream(
+                link,
+                AudioQuality.HIGH,
+                VideoQuality.HD_720p,
+                ytdlp_parameters=f'--proxy {PROXY}',
+            ),
+        )
+    except Exception as e:
+        LOGGER.error(e)
+        await msg.reply_text(str(e))
+        return None
+
+    await msg.reply_text("Live stream started.")
+    return None
+
+
 def get_youtube_stream_url(url: str) -> str:
     command = ["yt-dlp", "-g", "-f", "best", url]
 
@@ -582,13 +618,13 @@ def get_youtube_stream_url(url: str) -> str:
     )
 
     if result.returncode != 0:
-        print(f"Error getting stream URL: {result.stderr.strip()}")
+        LOGGER.error(f"Error getting stream URL: {result.stderr.strip() or result.stdout.strip()}")
         return ""
 
     return result.stdout.strip()
 
-@Client.on_message(filters=Filter.command(["live"]))
-async def live(_: Client, msg: types.Message) -> None:
+@Client.on_message(filters=Filter.command(["yt2"]))
+async def yt2(_: Client, msg: types.Message) -> None:
     """JUST FOR TESTING"""
     chat_id =  msg.chat_id
     user_id = msg.from_id
@@ -599,26 +635,6 @@ async def live(_: Client, msg: types.Message) -> None:
     if not link:
         return None
 
-    # try:
-    #     call_py = await call.group_assistant(chat_id)
-    #     if isinstance(call_py, types.Error):
-    #         await msg.reply_text(str(call_py))
-    #         return None
-    #
-    #     await call_py.play(
-    #         chat_id,
-    #         MediaStream(
-    #             link,
-    #             AudioQuality.HIGH,
-    #             VideoQuality.HD_720p,
-    #             ytdlp_parameters=f'--proxy {PROXY}',
-    #         ),
-    #     )
-    # except Exception as e:
-    #     LOGGER.error(e)
-    #     await msg.reply_text(str(e))
-    #     return None
-
     live_url = get_youtube_stream_url(link)
     if not live_url:
         await msg.reply_text("Live stream not found.")
@@ -628,6 +644,5 @@ async def live(_: Client, msg: types.Message) -> None:
     if isinstance(_call, types.Error):
         await msg.reply_text(str(_call))
         return None
-
     await msg.reply_text("Live stream started.")
     return None

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -3,16 +3,10 @@
 #  Part of the TgMusicBot project. All rights reserved where applicable.
 
 import re
-import subprocess
 from types import NoneType
 
 from pytdbot import Client, types
 
-from pytgcalls.types import AudioQuality
-from pytgcalls.types import MediaStream
-from pytgcalls.types import VideoQuality
-
-from src.config import OWNER_ID, PROXY
 from src.helpers import (
     CachedTrack,
     MusicServiceWrapper,

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -12,8 +12,7 @@ from pytgcalls.types import AudioQuality
 from pytgcalls.types import MediaStream
 from pytgcalls.types import VideoQuality
 
-from src import config
-from src.config import OWNER_ID
+from src.config import OWNER_ID, PROXY
 from src.helpers import (
     CachedTrack,
     MusicServiceWrapper,
@@ -570,12 +569,22 @@ async def play_file(_: Client, msg: types.Message) -> None:
 
 
 def get_youtube_stream_url(url: str) -> str:
+    command = ["yt-dlp", "-g", "-f", "best", url]
+
+    if PROXY:
+        command.extend(["--proxy",PROXY])
+
     result = subprocess.run(
-        ["yt-dlp", "-g", "-f", "best", url],
+        command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
+
+    if result.returncode != 0:
+        print(f"Error getting stream URL: {result.stderr.strip()}")
+        return ""
+
     return result.stdout.strip()
 
 @Client.on_message(filters=Filter.command(["live"]))
@@ -590,27 +599,26 @@ async def live(_: Client, msg: types.Message) -> None:
     if not link:
         return None
 
-    try:
-        call_py = await call.group_assistant(chat_id)
-        if isinstance(call_py, types.Error):
-            await msg.reply_text(str(call_py))
-            return None
+    # try:
+    #     call_py = await call.group_assistant(chat_id)
+    #     if isinstance(call_py, types.Error):
+    #         await msg.reply_text(str(call_py))
+    #         return None
+    #
+    #     await call_py.play(
+    #         chat_id,
+    #         MediaStream(
+    #             link,
+    #             AudioQuality.HIGH,
+    #             VideoQuality.HD_720p,
+    #             ytdlp_parameters=f'--proxy {PROXY}',
+    #         ),
+    #     )
+    # except Exception as e:
+    #     LOGGER.error(e)
+    #     await msg.reply_text(str(e))
+    #     return None
 
-        await call_py.play(
-            chat_id,
-            MediaStream(
-                link,
-                AudioQuality.HIGH,
-                VideoQuality.HD_720p,
-                ytdlp_parameters=f'--proxy {config.PROXY}',
-            ),
-        )
-    except Exception as e:
-        LOGGER.error(e)
-        await msg.reply_text(str(e))
-        return None
-
-    """ 
     live_url = get_youtube_stream_url(link)
     if not live_url:
         await msg.reply_text("Live stream not found.")
@@ -618,7 +626,8 @@ async def live(_: Client, msg: types.Message) -> None:
 
     _call = await call.play_media(chat_id, live_url, True)
     if isinstance(_call, types.Error):
+        await msg.reply_text(str(_call))
         return None
-    """
+
     await msg.reply_text("Live stream started.")
     return None

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -605,10 +605,11 @@ async def yt(_: Client, msg: types.Message) -> None:
 
 
 def get_youtube_stream_url(url: str) -> str:
-    command = ["yt-dlp", "-g", "-f", "best", url]
+    command = ["yt-dlp", "-g", "-f", "b", url]
 
     if PROXY:
-        command.extend(["--proxy",PROXY])
+        command.extend(["--proxy", PROXY])
+    command.extend(["--retries", "2", "--ignore-errors"])
 
     result = subprocess.run(
         command,
@@ -620,7 +621,6 @@ def get_youtube_stream_url(url: str) -> str:
     if result.returncode != 0:
         LOGGER.error(f"Error getting stream URL: {result.stderr.strip() or result.stdout.strip()}")
         return ""
-
     return result.stdout.strip()
 
 @Client.on_message(filters=Filter.command(["yt2"]))

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -561,89 +561,9 @@ async def play_file(_: Client, msg: types.Message) -> None:
 
     _call = await call.play_media(chat_id, link, True)
     if isinstance(_call, types.Error):
-        await edit_text(msg, text=f"⚠️ {str(_call)}")
+        await msg.reply_text(text=f"⚠️ {_call.message}")
         return None
 
     chat_cache.add_song(chat_id, CachedTrack(name="", artist="", track_id="", loop=0, duration=0, file_path=link, thumbnail="", user="", platform="", is_video=True, url=link, channel=channel))
-    return None
-
-
-@Client.on_message(filters=Filter.command(["yt"]))
-async def yt(_: Client, msg: types.Message) -> None:
-    """JUST FOR TESTING"""
-    chat_id =  msg.chat_id
-    user_id = msg.from_id
-    if user_id != OWNER_ID:
-        return None
-
-    link = extract_argument(msg.text)
-    if not link:
-        return None
-
-    try:
-        call_py = await call.group_assistant(chat_id)
-        if isinstance(call_py, types.Error):
-            await msg.reply_text(str(call_py))
-            return None
-
-        await call_py.play(
-            chat_id,
-            MediaStream(
-                link,
-                AudioQuality.HIGH,
-                VideoQuality.HD_720p,
-                audio_flags=MediaStream.Flags.REQUIRED,
-                ytdlp_parameters=f'--proxy {PROXY}',
-            ),
-        )
-    except Exception as e:
-        LOGGER.error(e)
-        await msg.reply_text(str(e))
-        return None
-
-    await msg.reply_text("Live stream started.")
-    return None
-
-
-def get_youtube_stream_url(url: str) -> str:
-    command = ["yt-dlp", "-g", "-f", "b", url]
-
-    if PROXY:
-        command.extend(["--proxy", PROXY])
-    command.extend(["--retries", "2", "--ignore-errors"])
-
-    result = subprocess.run(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-    if result.returncode != 0:
-        LOGGER.error(f"Error getting stream URL: {result.stderr.strip() or result.stdout.strip()}")
-        return ""
-    return result.stdout.strip()
-
-@Client.on_message(filters=Filter.command(["yt2"]))
-async def yt2(_: Client, msg: types.Message) -> None:
-    """JUST FOR TESTING"""
-    chat_id =  msg.chat_id
-    user_id = msg.from_id
-    if user_id != OWNER_ID:
-        return None
-
-    link = extract_argument(msg.text)
-    if not link:
-        return None
-
-    live_url = get_youtube_stream_url(link)
-    if not live_url:
-        await msg.reply_text("Live stream not found.")
-        return None
-
-    _call = await call.play_media(chat_id, live_url, True)
-    if isinstance(_call, types.Error):
-        await msg.reply_text(str(_call))
-        return None
-    await msg.reply_text("Live stream started.")
+    await msg.reply_text("✅ Direct link played.")
     return None


### PR DESCRIPTION
## Summary by Sourcery

Persist logs to a file and introduce a developer-only `/logs` command, simplify the assistant client method, enhance playback flags and error handling, and improve play command responses

New Features:
- Add `/logs` command restricted to developers to fetch the bot log file

Bug Fixes:
- Handle `NoAudioSourceFound` in playback to return a 404 error
- Fix direct link error reply to use the error’s message property

Enhancements:
- Persist logs to `bot.log` via a file handler
- Rename `_group_assistant` to `group_assistant` and update its usage
- Add required `audio_flags` to `play_media` calls
- Send a confirmation message after successfully playing a direct link