### PR TITLE
add progress bar for YT

### DIFF
--- a/src/helpers/_api.py
+++ b/src/helpers/_api.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Optional, Union
 
+from pytdbot import types
+
 from src import config
 from src.logger import LOGGER
 from ._dataclass import MusicTrack, PlatformTracks, TrackInfo
@@ -141,19 +143,7 @@ class ApiData(MusicService):
         data = await self._make_api_request("get_track", {"id": self.query})
         return TrackInfo(**data) if data else None
 
-    async def download_track(
-        self, track: TrackInfo, video: bool = False
-    ) -> Optional[Union[str, Path]]:
-        """
-        Download a track based on its platform.
-
-        Args:
-            track: TrackInfo object containing track details
-            video: Whether to download video (currently unused for API tracks)
-
-        Returns:
-            Path/str: Path to a downloaded file or None if failed
-        """
+    async def download_track(self, track: TrackInfo, video: bool = False, msg: Union[None, types.Message]= None) -> Optional[Union[str, Path]]:
         if not track:
             return None
 

--- a/src/helpers/_downloader.py
+++ b/src/helpers/_downloader.py
@@ -3,7 +3,9 @@
 #  Part of the TgMusicBot project. All rights reserved where applicable.
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Union
+
+from pytdbot import types
 
 from src import config
 from ._dataclass import PlatformTracks, TrackInfo
@@ -64,15 +66,14 @@ class MusicService(ABC):
         pass
 
     @abstractmethod
-    async def download_track(
-        self, track_info: TrackInfo, video: bool = False
-    ) -> Optional[str]:
+    async def download_track(self, track_info: TrackInfo, video: bool = False, msg: Union[None, types.Message] = None) -> Optional[str]:
         """
         Download a track from the music service.
 
         Args:
             track_info: Track information containing the track ID or URL to download.
             video: Whether to download video or audio (default: False)
+            msg: Optional message to update with progress (default: None)
 
         Returns:
             Optional[str]: Path to the downloaded file if successful, or None if download fails.
@@ -141,7 +142,5 @@ class MusicServiceWrapper(MusicService):
     async def get_track(self) -> Optional[TrackInfo]:
         return await self.service.get_track()
 
-    async def download_track(
-        self, track_info: TrackInfo, video: bool = False
-    ) -> Optional[str]:
+    async def download_track(self, track_info: TrackInfo, video: bool = False, msg: Union[None, types.Message]= None) -> Optional[str]:
         return await self.service.download_track(track_info)

--- a/src/helpers/_jiosaavn.py
+++ b/src/helpers/_jiosaavn.py
@@ -4,10 +4,12 @@
 
 import asyncio
 import re
-from pathlib import Path
-from typing import Any, Optional
-
 import yt_dlp
+
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from pytdbot import types
 
 from src import config
 from src.logger import LOGGER
@@ -213,19 +215,7 @@ class JiosaavnData(MusicService):
             LOGGER.error("Unexpected error getting playlist %s: %s", url, str(e))
         return None
 
-    async def download_track(
-        self, track: TrackInfo, video: bool = False
-    ) -> Optional[Path]:
-        """
-        Download a track to local storage.
-
-        Args:
-            track: TrackInfo object containing download details
-            video: Whether to download video or audio
-
-        Returns:
-            Optional[Path]: Path to downloaded file or None if failed
-        """
+    async def download_track(self, track: TrackInfo, video: bool = False, msg: Union[None, types.Message]= None) -> Optional[Path]:
         if not track or not track.cdnurl:
             return None
 

--- a/src/helpers/_lang.py
+++ b/src/helpers/_lang.py
@@ -34,15 +34,12 @@ def get_string(key: str, lang: str = DEFAULT_LANG) -> str:
     if text is not None:
         return text
 
-    # Fallback to default language
     text = langs.get(DEFAULT_LANG, {}).get(key)
     if text is not None:
         logger.warning(
             f"Missing key '{key}' in '{lang}', using fallback from '{DEFAULT_LANG}'."
         )
         return text
-
-    # If missing in default too
     logger.error(
         f"Missing key '{key}' in both '{lang}' and default language '{DEFAULT_LANG}'."
     )
@@ -53,18 +50,8 @@ def load_translations():
     for f_name in os.listdir(LANG_DIR):
         lang_code = f_name.replace(".json", "")
         file_path = os.path.join(LANG_DIR, f_name)
-        try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                langs[lang_code] = json.load(f)
-        except json.JSONDecodeError as e:
-            logger.warning(
-                f"Error decoding JSON for language '{lang_code}' in file '{f_name}': {e}"
-            )
-        except Exception as e:
-            logger.error(
-                f"Error decoding JSON for language '{lang_code}': {e}", exc_info=True
-            )
-
+        with open(file_path, "r", encoding="utf-8") as f:
+            langs[lang_code] = json.load(f)
 
 def generate_lang_buttons() -> types.ReplyMarkupInlineKeyboard:
     buttons = []

--- a/src/helpers/_pytgcalls.py
+++ b/src/helpers/_pytgcalls.py
@@ -304,7 +304,7 @@ class Call:
                 return
 
             # Download song if isn't downloaded
-            file_path = song.file_path or await self.song_download(song)
+            file_path = song.file_path or await self.song_download(song, reply)
             if not file_path:
                 await reply.edit_text(
                     "⚠️ Failed to download the song.\n" "Skipping to next track..."
@@ -374,15 +374,7 @@ class Call:
             )
 
     @staticmethod
-    async def song_download(song: CachedTrack) -> Optional[Path]:
-        """Download a song from its source platform.
-
-        Args:
-            song: CachedTrack object containing song metadata
-
-        Returns:
-            Path to downloaded file or None if failed
-        """
+    async def song_download(song: CachedTrack, msg: Union[types.Message, None]) -> Optional[Path]:
         platform_handlers = {
             "youtube": YouTubeData(song.track_id),
             "jiosaavn": JiosaavnData(song.url),
@@ -400,7 +392,7 @@ class Call:
 
         try:
             track = await handler.get_track()
-            return await handler.download_track(track, song.is_video) if track else None
+            return await handler.download_track(track, song.is_video, msg) if track else None
         except Exception as e:
             LOGGER.error(
                 "Download failed for %s: %s", song.track_id, str(e), exc_info=True

--- a/src/helpers/_telegram.py
+++ b/src/helpers/_telegram.py
@@ -24,9 +24,9 @@ class Telegram:
     )
     DownloaderCache = TTLCache(maxsize=5000, ttl=600)
 
-    def __init__(self, reply: Optional[types.Message]):
-        self.msg = reply
-        self.content = reply.content if reply else None
+    def __init__(self, dl_msg: Optional[types.Message]):
+        self.msg = dl_msg
+        self.content = dl_msg.content if dl_msg else None
         self._file_info: Optional[tuple[int, str]] = None
 
     @property
@@ -78,9 +78,7 @@ class Telegram:
         LOGGER.info("Unsupported content type: %s", type(self.content).__name__)
         return 0, "UnknownMedia"
 
-    async def dl(
-        self, message: types.Message
-    ) -> tuple[Union[types.Error, types.LocalFile], str]:
+    async def download_msg(self, message: types.Message) -> tuple[Union[types.Error, types.LocalFile], str]:
         if not self.is_valid():
             return (
                 types.Error(message="Invalid or unsupported media file."),

--- a/src/helpers/_youtube.py
+++ b/src/helpers/_youtube.py
@@ -231,6 +231,10 @@ class YouTubeUtils:
                 LOGGER.error("Response from API is empty")
                 return None
 
+            if not re.match(r"https:\/\/t\.me\/([a-zA-Z0-9_]{5,})\/(\d+)", dl_url):
+                dl = await HttpxClient().download_file(f"{API_URL}/stream?uuid={dl_url}")
+                return dl.file_path if dl.success else None
+
             info = await client.getMessageLinkInfo(dl_url)
             if isinstance(info, types.Error) or info.message is None:
                 LOGGER.error(f"❌ Could not resolve message from link: {dl_url}; {info}")

--- a/src/helpers/_youtube.py
+++ b/src/helpers/_youtube.py
@@ -15,6 +15,7 @@ from pytdbot import types
 from src.helpers import MusicTrack, PlatformTracks, TrackInfo
 from src.logger import LOGGER
 from ._downloader import MusicService
+from ._telegram import Telegram
 from ._httpx import HttpxClient
 from ..config import API_URL, API_KEY, DOWNLOADS_DIR, PROXY
 
@@ -219,7 +220,7 @@ class YouTubeUtils:
         return None
 
     @staticmethod
-    async def download_with_api(video_id: str) -> Optional[Path]:
+    async def download_with_api(video_id: str, reply: Union[None, types.Message]) -> Optional[Path]:
         """
         Download audio using the API.
         """
@@ -240,7 +241,7 @@ class YouTubeUtils:
                 LOGGER.error(f"❌ Failed to fetch message with ID {info.message.id}; {msg}")
                 return None
 
-            file = await msg.download()
+            file, _ = await Telegram(msg).download_msg(reply)
             if isinstance(file, types.Error):
                 LOGGER.error(f"❌ Failed to download message with ID {info.message.id}; {file}")
                 return None
@@ -377,25 +378,13 @@ class YouTubeData(MusicService):
             LOGGER.error(f"Error fetching track {self.query}: {e!r}")
             return None
 
-    async def download_track(
-        self, track: TrackInfo, video: bool = False
-    ) -> Union[Path, str, None]:
-        """
-        Download a YouTube track.
-
-        Args:
-            track: TrackInfo object containing track details
-            video: Whether to download video (True) or audio only (False)
-
-        Returns:
-            str: Path to downloaded file or None if failed
-        """
+    async def download_track(self, track: TrackInfo, video: bool = False, msg: Union[None, types.Message]= None) -> Union[Path, str, None]:
         if not track:
             return None
 
         try:
             if not video and API_URL and API_KEY:
-                if file_path := await YouTubeUtils.download_with_api(track.tc):
+                if file_path := await YouTubeUtils.download_with_api(track.tc, msg):
                     return file_path
 
             return await YouTubeUtils.download_with_yt_dlp(track.tc, video)

--- a/src/helpers/_youtube.py
+++ b/src/helpers/_youtube.py
@@ -231,7 +231,7 @@ class YouTubeUtils:
                 LOGGER.error("Response from API is empty")
                 return None
 
-            if not re.match(r"https:\/\/t\.me\/([a-zA-Z0-9_]{5,})\/(\d+)", dl_url):
+            if not re.fullmatch(r"https:\/\/t\.me\/([a-zA-Z0-9_]{5,})\/(\d+)", dl_url):
                 dl = await HttpxClient().download_file(f"{API_URL}/stream?uuid={dl_url}")
                 return dl.file_path if dl.success else None
 
@@ -249,6 +249,7 @@ class YouTubeUtils:
             if isinstance(file, types.Error):
                 LOGGER.error(f"❌ Failed to download message with ID {info.message.id}; {file}")
                 return None
+
             return file.path
         return None
 

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -149,7 +149,7 @@ async def _handle_single_track(
     )
 
     if not song.file_path:
-        if file_path := await call.song_download(song):
+        if file_path := await call.song_download(song, msg):
             song.file_path = file_path
         else:
             return await edit_text(
@@ -338,7 +338,7 @@ async def _handle_telegram_file(
     is_video = isinstance(content, types.MessageVideo) or docs_vid
 
     # Download the file
-    file_path, file_name = await telegram.dl(reply_message)
+    file_path, file_name = await telegram.download_msg(reply_message)
     if isinstance(file_path, types.Error):
         return await edit_text(
             reply_message,

--- a/src/modules/play.py
+++ b/src/modules/play.py
@@ -96,7 +96,7 @@ async def _update_msg_with_thumb(
     Update a message with thumbnail if available.
     """
     if not thumb:
-        return await edit_text(msg, text=text, reply_markup=button)
+        return await edit_text(msg, text=text, reply_markup=button, disable_web_page_preview=True)
 
     parsed_text = await c.parseTextEntities(text, types.TextParseModeHTML())
     if isinstance(parsed_text, types.Error):

--- a/src/modules/stream.py
+++ b/src/modules/stream.py
@@ -95,7 +95,7 @@ async def stream_cmd(_: Client, msg: types.Message) -> None:
 
     reply_message = await msg.reply_text("📥 Downloading file...")
 
-    file_path, file_name = await telegram.dl(reply_message)
+    file_path, file_name = await telegram.download_msg(reply_message)
     if isinstance(file_path, types.Error):
         await edit_text(
             reply_message,

--- a/src/modules/utils/play_helpers.py
+++ b/src/modules/utils/play_helpers.py
@@ -101,7 +101,7 @@ async def edit_text(
         LOGGER.warning("Error getting message: %s", reply_message)
         return reply_message
 
-    reply = await reply_message.edit_text(disable_web_page_preview=True, *args, **kwargs)
+    reply = await reply_message.edit_text(*args, **kwargs)
     if isinstance(reply, types.Error):
         if reply.code == 429:
             retry_after = (


### PR DESCRIPTION
## Summary by Sourcery

Enable progress bar updates by passing reply messages into download workflows, unify download helper interfaces, streamline translation loading, and disable web page previews on message edits.

Enhancements:
- Propagate Telegram reply message through all download_track methods to enable progress reporting
- Rename Telegram.dl to download_msg and update related method signatures for consistency
- Simplify language loader by removing JSON error handling and enforcing direct load of translation files
- Ensure web page previews are disabled when editing messages in play and stream modules