### PR TITLE
bump mongo-driver from version 1.x to 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@
 /downloads
 ntgcalls.h
 libntgcalls.a
-tgmusic
-gosec_report.json
-/scripts

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/amarnathcjd/gogram v1.6.5-0.20251027103927-ffd9d80f4671
 	github.com/joho/godotenv v1.5.1
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	go.mongodb.org/mongo-driver v1.17.6
+	go.mongodb.org/mongo-driver/v2 v2.4.0
 )
 
 require (
@@ -25,7 +25,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
-github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -61,8 +59,8 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfS
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=
-go.mongodb.org/mongo-driver v1.17.6/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver/v2 v2.4.0 h1:Oq6BmUAAFTzMeh6AonuDlgZMuAuEiUxoAD1koK5MuFo=
+go.mongodb.org/mongo-driver/v2 v2.4.0/go.mod h1:jHeEDJHJq7tm6ZF45Issun9dbogjfnPySb1vXA7EeAI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=

--- a/pkg/core/db/utilities.go
+++ b/pkg/core/db/utilities.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/Laky-64/gologging"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 var ctxBg = context.Background()
@@ -36,7 +36,7 @@ func getIntSlice(v interface{}) ([]int64, bool) {
 		return val, true
 	case []interface{}:
 		return convertInterfaceSlice(val)
-	case primitive.A:
+	case bson.A:
 		return convertInterfaceSlice([]interface{}(val))
 	default:
 		gologging.InfoF("Unexpected type encountered in getIntSlice: %T", v)

--- a/pkg/handlers/filters.go
+++ b/pkg/handlers/filters.go
@@ -162,6 +162,7 @@ func playMode(m *telegram.NewMessage) bool {
 	if m.IsPrivate() {
 		return false
 	}
+
 	chatID, err := getPeerId(m.Client, m.ChatID())
 	if err != nil {
 		gologging.WarnF("getPeerId error: %v", err)
@@ -191,6 +192,7 @@ func playMode(m *telegram.NewMessage) bool {
 		_, _ = m.Reply(lang.GetString(langCode, "filter_bot_no_invite_permission"))
 		return false
 	}
+
 	getPlayMode := db.Instance.GetPlayMode(ctx, chatID)
 	if getPlayMode != cache.Everyone {
 		admins, err := cache.GetAdmins(m.Client, chatID, false)


### PR DESCRIPTION
## Summary by Sourcery

Upgrade MongoDB Go driver to v2, update import paths and API calls, and refresh module dependencies

Enhancements:
- Migrate imports to go.mongodb.org/mongo-driver/v2 and adjust mongo.Connect signature
- Replace options.Update calls with options.UpdateOne to align with driver v2 API

Build:
- Bump go.mongodb.org/mongo-driver requirement to v2.4.0 in go.mod and remove an unused indirect dependency

Chores:
- Replace primitive.A with bson.A in utilities and apply minor formatting tweaks