### PR TITLE
feat: Add Deno dependency for yt-dlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \
     zlib1g \
+    unzip \
     && wget -O /usr/local/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux \
     && chmod +x /usr/local/bin/yt-dlp \
+    && curl -fsSL https://deno.land/install.sh | sh \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -119,16 +119,18 @@ Deploying with Docker is the easiest and recommended method.
 ##### Prerequisites
 - [Go](https://golang.org/doc/install) (version 1.24.4 or higher)
 - [FFmpeg](https://ffmpeg.org/download.html)
+- [Deno](https://deno.com/)
 
 ##### Steps
 1.  **Install prerequisites:**
     - **On Debian/Ubuntu:**
       ```sh
       sudo apt-get update && sudo apt-get install -y golang ffmpeg
+      curl -fsSL https://deno.land/install.sh | sh
       ```
     - **On macOS (using Homebrew):**
       ```sh
-      brew install go ffmpeg
+      brew install go ffmpeg deno
       ```
 
 2.  **Clone the repository and create the `.env` file** as described in the [Configuration](#-configuration) section.
@@ -149,11 +151,16 @@ Deploying with Docker is the easiest and recommended method.
 ##### Prerequisites
 - [Go](https://golang.org/doc/install) (version 1.24.4 or higher)
 - [FFmpeg](https://ffmpeg.org/download.html)
+- [Deno](https://deno.com/)
 
 ##### Steps
 1.  **Install prerequisites:**
     - Download and install Go from the [official website](https://golang.org/doc/install).
     - Download FFmpeg from the [official website](https://ffmpeg.org/download.html) and add it to your system's PATH.
+    - Install Deno using PowerShell:
+      ```powershell
+      irm https://deno.land/install.ps1 | iex
+      ```
 
 2.  **Clone the repository** as described in the [Configuration](#-configuration) section.
 


### PR DESCRIPTION
Include Deno as a dependency for yt-dlp, which is now required for YouTube downloads to function correctly.

More info see: https://github.com/yt-dlp/yt-dlp/issues/14404

## Summary by Sourcery

Include Deno as a required dependency for yt-dlp and update installation workflows to install it locally and in Docker.

Enhancements:
- Add Deno to prerequisites for Debian/Ubuntu, macOS, and Windows local installations.

Build:
- Install unzip and run the Deno install script in the Dockerfile.

Documentation:
- Update installation.md with Deno installation steps across all supported platforms.