### PR TITLE
Refactor DB context handling and standardize downloader APIs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -195,7 +195,7 @@ If you find this project useful, consider supporting its development with a dona
 
 - 📦 Repo: [TgMusicBot on GitHub](https://github.com/AshokShau/TgMusicBot)
 - 💬 Support: [Telegram Group](https://t.me/FallenProjects)
-- 🐍 Old version: [TgMusicBot (Python)](https://github.com/AshokShau/TgMusicBot/tree/python) (Deprecated)
+- 🐍 Old version: [TgMusicBot (Python)](https://github.com/FallenProjects/music-bot)
 
 ---
 

--- a/config/save_cookies.go
+++ b/config/save_cookies.go
@@ -21,8 +21,6 @@ import (
 const cookiesDr = "src/cookies"
 
 // fetchContent downloads content from Pastebin or Batbin.
-// It takes a URL as input.
-// It returns the content of the URL as a string and an error if any.
 func fetchContent(url string) (string, error) {
 	parts := strings.Split(strings.Trim(url, "/"), "/")
 	id := parts[len(parts)-1]
@@ -57,8 +55,6 @@ func fetchContent(url string) (string, error) {
 }
 
 // saveContent saves content to a file in /tmp and returns the file path.
-// It takes a URL and content as input.
-// It returns the file path and an error if any.
 func saveContent(url, content string) (string, error) {
 	parts := strings.Split(strings.Trim(url, "/"), "/")
 	filename := parts[len(parts)-1]
@@ -68,7 +64,7 @@ func saveContent(url, content string) (string, error) {
 	filename += ".txt"
 
 	filePath := filepath.Join(cookiesDr, filename)
-	// #nosec G304
+
 	f, err := os.Create(filePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to create file %s: %w", filePath, err)

--- a/config/types.go
+++ b/config/types.go
@@ -157,7 +157,7 @@ func (c *BotConfig) validate() error {
 
 	if !isValidService(c.DefaultService) {
 		c.DefaultService = "youtube"
-		slog.Info("Invalid DEFAULT_SERVICE '', defaulting to 'youtube'", "arg1", c.DefaultService)
+		slog.Info("Invalid DEFAULT_SERVICE, defaulting to 'youtube'", "Service", c.DefaultService)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -43,14 +43,11 @@ func main() {
 			Level:     slog.LevelInfo,
 			AddSource: true,
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-
-				// Shorter time
 				if a.Key == slog.TimeKey {
 					t := a.Value.Time()
 					a.Value = slog.StringValue(t.Format("2006-01-02 15:04:05"))
 				}
 
-				// Short source (file.go:line)
 				if a.Key == slog.SourceKey {
 					source := a.Value.Any().(*slog.Source)
 					a.Value = slog.StringValue(fmt.Sprintf("%s:%d", filepath.Base(source.File), source.Line))
@@ -66,6 +63,10 @@ func main() {
 	clientConfig := &gotdbot.ClientOpts{
 		LibraryPath: "./libtdjson.so.1.8.63",
 		Logger:      logger,
+		AutoRetry: &gotdbot.AutoRetry{
+			ChatNotFound: true,
+		},
+		DatabaseDirectory: "database",
 	}
 
 	client, err := gotdbot.NewClient(config.Conf.ApiId, config.Conf.ApiHash, config.Conf.Token, clientConfig)
@@ -79,6 +80,7 @@ func main() {
 		slog.Error("gotdbot.Start() error", "error", err)
 		os.Exit(1)
 	}
+
 	err = src.Init(client)
 	if err != nil {
 		panic(err)

--- a/src/core/buttons.go
+++ b/src/core/buttons.go
@@ -58,35 +58,45 @@ func SupportKeyboard() *gotdbot.ReplyMarkupInlineKeyboard {
 	}
 }
 
-func SettingsKeyboard(playMode, adminMode string) *gotdbot.ReplyMarkupInlineKeyboard {
+func SettingsKeyboard(playMode, adminMode string, cmdDelete bool, language string) *gotdbot.ReplyMarkupInlineKeyboard {
+	playText := "Everyone"
+	if playMode == utils.Admins {
+		playText = "Admins"
+	}
 
-	createButton := func(label, settingType, settingValue, currentValue string) gotdbot.InlineKeyboardButton {
+	deleteText := "False"
+	if cmdDelete {
+		deleteText = "True"
+	}
 
-		text := label
-		if settingValue == currentValue {
-			text += " ✅"
-		}
+	adminText := "Everyone"
+	if adminMode == utils.Admins {
+		adminText = "Admins"
+	}
 
-		return cb(text, fmt.Sprintf("settings_%s_%s", settingType, settingValue))
+	langText := "English"
+	if language != "en" && language != "" {
+		langText = language
 	}
 
 	return &gotdbot.ReplyMarkupInlineKeyboard{
 		Rows: [][]gotdbot.InlineKeyboardButton{
-
-			{cb("🎵 Play Mode", "settings_xxx_noop")},
-
 			{
-				createButton("Admins", "play", utils.Admins, playMode),
-				createButton("Everyone", "play", utils.Everyone, playMode),
+				cb("Play Mode ➜", "settings_main"),
+				cb(playText, "settings_play"),
 			},
-
-			{cb("🛡️ Admin Mode", "settings_xxx_none")},
-
 			{
-				createButton("Admins", "admin", utils.Admins, adminMode),
-				createButton("Everyone", "admin", utils.Everyone, adminMode),
+				cb("Command Delete ➜", "settings_main"),
+				cb(deleteText, "settings_delete"),
 			},
-
+			{
+				cb("Admin Mode ➜", "settings_main"),
+				cb(adminText, "settings_admin"),
+			},
+			{
+				cb("Language ➜", "settings_main"),
+				cb(langText, "settings_lang"),
+			},
 			{CloseBtn},
 		},
 	}

--- a/src/core/db/assistant.go
+++ b/src/core/db/assistant.go
@@ -9,7 +9,6 @@
 package db
 
 import (
-	"context"
 	"errors"
 	"log/slog"
 
@@ -20,7 +19,7 @@ import (
 
 // GetAssistant retrieves the index of the assistant for a chat.
 // Returns -1 if no assistant is assigned.
-func (db *Database) GetAssistant(ctx context.Context, chatID int64) (int, error) {
+func (db *Database) GetAssistant(chatID int64) (int, error) {
 	key := toKey(chatID)
 	if cached, ok := db.assistantCache.Get(key); ok {
 		return cached, nil
@@ -28,6 +27,10 @@ func (db *Database) GetAssistant(ctx context.Context, chatID int64) (int, error)
 	var doc struct {
 		Num int `bson:"num"`
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	err := db.assistantDB.FindOne(ctx, bson.M{"_id": chatID}).Decode(&doc)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -40,16 +43,23 @@ func (db *Database) GetAssistant(ctx context.Context, chatID int64) (int, error)
 }
 
 // SetAssistant sets the assistant index for a given chat.
-func (db *Database) SetAssistant(ctx context.Context, chatID int64, num int) error {
+func (db *Database) SetAssistant(chatID int64, num int) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.assistantDB.UpdateOne(ctx, bson.M{"_id": chatID}, bson.M{"$set": bson.M{"num": num}}, options.UpdateOne().SetUpsert(true))
 	if err == nil {
 		db.assistantCache.Set(toKey(chatID), num)
 	}
+
 	return err
 }
 
 // RemoveAssistant removes the assistant from a chat's settings.
-func (db *Database) RemoveAssistant(ctx context.Context, chatID int64) error {
+func (db *Database) RemoveAssistant(chatID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.assistantDB.DeleteOne(ctx, bson.M{"_id": chatID})
 	if err == nil {
 		db.assistantCache.Delete(toKey(chatID))
@@ -58,7 +68,10 @@ func (db *Database) RemoveAssistant(ctx context.Context, chatID int64) error {
 }
 
 // AssignAssistant attempts to set the assistant for a chat if it is not currently set.
-func (db *Database) AssignAssistant(ctx context.Context, chatID int64, proposedAssistant int) (int, error) {
+func (db *Database) AssignAssistant(chatID int64, proposedAssistant int) (int, error) {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	filter := bson.M{
 		"_id": chatID,
 		"$or": bson.A{
@@ -72,7 +85,7 @@ func (db *Database) AssignAssistant(ctx context.Context, chatID int64, proposedA
 	result, err := db.assistantDB.UpdateOne(ctx, filter, update, opts)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
-			return db.GetAssistant(ctx, chatID)
+			return db.GetAssistant(chatID)
 		}
 		return -1, err
 	}
@@ -82,16 +95,20 @@ func (db *Database) AssignAssistant(ctx context.Context, chatID int64, proposedA
 		return proposedAssistant, nil
 	}
 
-	return db.GetAssistant(ctx, chatID)
+	return db.GetAssistant(chatID)
 }
 
 // ClearAllAssistants removes all assistant assignments.
-func (db *Database) ClearAllAssistants(ctx context.Context) (int64, error) {
+func (db *Database) ClearAllAssistants() (int64, error) {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	result, err := db.assistantDB.DeleteMany(ctx, bson.M{})
 	if err != nil {
 		slog.Info("[DB] Error clearing assistants", "error", err)
 		return 0, err
 	}
+
 	db.assistantCache.Clear()
 	return result.DeletedCount, nil
 }

--- a/src/core/db/auth.go
+++ b/src/core/db/auth.go
@@ -10,19 +10,22 @@ package db
 
 import (
 	"ashokshau/tgmusic/src/core/cache"
-	"context"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // AddAuthUser adds a user to the list of authorized users for a chat.
-func (db *Database) AddAuthUser(ctx context.Context, chatID, userID int64) error {
+func (db *Database) AddAuthUser(chatID, userID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.authDB.UpdateOne(ctx,
 		bson.M{"_id": chatID},
 		bson.M{"$addToSet": bson.M{"user_ids": userID}},
 		options.UpdateOne().SetUpsert(true),
 	)
+
 	if err == nil {
 		db.authCache.Delete(toKey(chatID))
 	}
@@ -30,7 +33,10 @@ func (db *Database) AddAuthUser(ctx context.Context, chatID, userID int64) error
 }
 
 // RemoveAuthUser removes a user from the list of authorized users for a chat.
-func (db *Database) RemoveAuthUser(ctx context.Context, chatID, userID int64) error {
+func (db *Database) RemoveAuthUser(chatID, userID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.authDB.UpdateOne(ctx,
 		bson.M{"_id": chatID},
 		bson.M{"$pull": bson.M{"user_ids": userID}},
@@ -42,11 +48,15 @@ func (db *Database) RemoveAuthUser(ctx context.Context, chatID, userID int64) er
 }
 
 // GetAuthUsers retrieves a list of all authorized users for a chat.
-func (db *Database) GetAuthUsers(ctx context.Context, chatID int64) []int64 {
+func (db *Database) GetAuthUsers(chatID int64) []int64 {
 	key := toKey(chatID)
 	if cached, ok := db.authCache.Get(key); ok {
 		return cached
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	var doc struct {
 		UserIDs []int64 `bson:"user_ids"`
 	}
@@ -59,7 +69,7 @@ func (db *Database) GetAuthUsers(ctx context.Context, chatID int64) []int64 {
 }
 
 // IsAuthUser checks if a specific user is in the list of authorized users for a chat.
-func (db *Database) IsAuthUser(ctx context.Context, chatID, userID int64) bool {
+func (db *Database) IsAuthUser(chatID, userID int64) bool {
 	admins, err := cache.GetChatAdminIDs(chatID)
 	if err != nil || admins == nil {
 		admins = []int64{}
@@ -69,12 +79,12 @@ func (db *Database) IsAuthUser(ctx context.Context, chatID, userID int64) bool {
 		return true
 	}
 
-	users := db.GetAuthUsers(ctx, chatID)
+	users := db.GetAuthUsers(chatID)
 	return contains(users, userID)
 }
 
 // IsAdmin checks if a specific user is an administrator in a chat.
-func (db *Database) IsAdmin(_ context.Context, chatID, userID int64) bool {
+func (db *Database) IsAdmin(chatID, userID int64) bool {
 	admins, err := cache.GetChatAdminIDs(chatID)
 	if err != nil || admins == nil {
 		admins = []int64{}

--- a/src/core/db/blacklist.go
+++ b/src/core/db/blacklist.go
@@ -9,14 +9,15 @@
 package db
 
 import (
-	"context"
-
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // AddBlacklistedChat adds a chat to the blacklist.
-func (db *Database) AddBlacklistedChat(ctx context.Context, chatID int64) error {
+func (db *Database) AddBlacklistedChat(chatID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.cacheDB.UpdateOne(ctx,
 		bson.M{"_id": "bl_chats"},
 		bson.M{"$addToSet": bson.M{"chat_ids": chatID}},
@@ -29,7 +30,10 @@ func (db *Database) AddBlacklistedChat(ctx context.Context, chatID int64) error 
 }
 
 // RemoveBlacklistedChat removes a chat from the blacklist.
-func (db *Database) RemoveBlacklistedChat(ctx context.Context, chatID int64) error {
+func (db *Database) RemoveBlacklistedChat(chatID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.cacheDB.UpdateOne(ctx,
 		bson.M{"_id": "bl_chats"},
 		bson.M{"$pull": bson.M{"chat_ids": chatID}},
@@ -41,13 +45,17 @@ func (db *Database) RemoveBlacklistedChat(ctx context.Context, chatID int64) err
 }
 
 // GetBlacklistedChats retrieves the list of blacklisted chat IDs.
-func (db *Database) GetBlacklistedChats(ctx context.Context) []int64 {
+func (db *Database) GetBlacklistedChats() []int64 {
 	if cached, ok := db.blChatsCache.Get("bl_chats"); ok {
 		return cached
 	}
 	var doc struct {
 		ChatIDs []int64 `bson:"chat_ids"`
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	err := db.cacheDB.FindOne(ctx, bson.M{"_id": "bl_chats"}).Decode(&doc)
 	if err != nil {
 		return []int64{}
@@ -57,13 +65,16 @@ func (db *Database) GetBlacklistedChats(ctx context.Context) []int64 {
 }
 
 // IsBlacklistedChat checks if a chat is blacklisted.
-func (db *Database) IsBlacklistedChat(ctx context.Context, chatID int64) bool {
-	chats := db.GetBlacklistedChats(ctx)
+func (db *Database) IsBlacklistedChat(chatID int64) bool {
+	chats := db.GetBlacklistedChats()
 	return contains(chats, chatID)
 }
 
 // AddBlacklistedUser adds a user to the blacklist.
-func (db *Database) AddBlacklistedUser(ctx context.Context, userID int64) error {
+func (db *Database) AddBlacklistedUser(userID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.cacheDB.UpdateOne(ctx,
 		bson.M{"_id": "bl_users"},
 		bson.M{"$addToSet": bson.M{"user_ids": userID}},
@@ -76,7 +87,10 @@ func (db *Database) AddBlacklistedUser(ctx context.Context, userID int64) error 
 }
 
 // RemoveBlacklistedUser removes a user from the blacklist.
-func (db *Database) RemoveBlacklistedUser(ctx context.Context, userID int64) error {
+func (db *Database) RemoveBlacklistedUser(userID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.cacheDB.UpdateOne(ctx,
 		bson.M{"_id": "bl_users"},
 		bson.M{"$pull": bson.M{"user_ids": userID}},
@@ -88,13 +102,17 @@ func (db *Database) RemoveBlacklistedUser(ctx context.Context, userID int64) err
 }
 
 // GetBlacklistedUsers retrieves the list of blacklisted user IDs.
-func (db *Database) GetBlacklistedUsers(ctx context.Context) []int64 {
+func (db *Database) GetBlacklistedUsers() []int64 {
 	if cached, ok := db.blUsersCache.Get("bl_users"); ok {
 		return cached
 	}
 	var doc struct {
 		UserIDs []int64 `bson:"user_ids"`
 	}
+	
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	err := db.cacheDB.FindOne(ctx, bson.M{"_id": "bl_users"}).Decode(&doc)
 	if err != nil {
 		return []int64{}
@@ -104,7 +122,7 @@ func (db *Database) GetBlacklistedUsers(ctx context.Context) []int64 {
 }
 
 // IsBlacklistedUser checks if a user is blacklisted.
-func (db *Database) IsBlacklistedUser(ctx context.Context, userID int64) bool {
-	users := db.GetBlacklistedUsers(ctx)
+func (db *Database) IsBlacklistedUser(userID int64) bool {
+	users := db.GetBlacklistedUsers()
 	return contains(users, userID)
 }

--- a/src/core/db/chats.go
+++ b/src/core/db/chats.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"ashokshau/tgmusic/src/utils"
 	"context"
 	"errors"
 	"log/slog"
@@ -29,7 +30,7 @@ type Chats struct {
 }
 
 // getChat retrieves a chat's data from the cache or database.
-func (db *Database) getChat(ctx context.Context, chatID int64) (*Chats, error) {
+func (db *Database) getChat(chatID int64) (*Chats, error) {
 	key := toKey(chatID)
 	if cached, ok := db.chatCache.Get(key); ok {
 		return cached, nil
@@ -37,6 +38,9 @@ func (db *Database) getChat(ctx context.Context, chatID int64) (*Chats, error) {
 
 	var chat Chats
 	var err error
+
+	ctx, cancel := db.ctx()
+	defer cancel()
 
 	for i := 0; i < 3; i++ {
 		err = db.chatDB.FindOne(ctx, bson.M{"_id": chatID}).Decode(&chat)
@@ -63,11 +67,14 @@ func (db *Database) getChat(ctx context.Context, chatID int64) (*Chats, error) {
 }
 
 // AddChat adds a new chat to the database if it does not already exist.
-func (db *Database) AddChat(ctx context.Context, chatID int64) error {
-	chat, _ := db.getChat(ctx, chatID)
+func (db *Database) AddChat(chatID int64) error {
+	chat, _ := db.getChat(chatID)
 	if chat != nil {
 		return nil // Chat already exists.
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
 
 	_, err := db.chatDB.UpdateOne(ctx, bson.M{"_id": chatID}, bson.M{"$setOnInsert": bson.M{}}, options.UpdateOne().SetUpsert(true))
 	if err == nil {
@@ -77,8 +84,8 @@ func (db *Database) AddChat(ctx context.Context, chatID int64) error {
 }
 
 // GetPlayType retrieves the play type setting for a chat.
-func (db *Database) GetPlayType(ctx context.Context, chatID int64) int {
-	chat, _ := db.getChat(ctx, chatID)
+func (db *Database) GetPlayType(chatID int64) int {
+	chat, _ := db.getChat(chatID)
 	if chat == nil {
 		return 0
 	}
@@ -86,7 +93,10 @@ func (db *Database) GetPlayType(ctx context.Context, chatID int64) int {
 }
 
 // SetPlayType sets the play type for a given chat.
-func (db *Database) SetPlayType(ctx context.Context, chatID int64, playType int) error {
+func (db *Database) SetPlayType(chatID int64, playType int) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.chatDB.UpdateOne(ctx, bson.M{"_id": chatID}, bson.M{"$set": bson.M{"play_type": playType}}, options.UpdateOne().SetUpsert(true))
 	if err == nil {
 		db.chatCache.Delete(toKey(chatID))
@@ -95,8 +105,8 @@ func (db *Database) SetPlayType(ctx context.Context, chatID int64, playType int)
 }
 
 // GetPlayMode retrieves the play mode for a chat.
-func (db *Database) GetPlayMode(ctx context.Context, chatID int64) bool {
-	chat, _ := db.getChat(ctx, chatID)
+func (db *Database) GetPlayMode(chatID int64) bool {
+	chat, _ := db.getChat(chatID)
 	if chat == nil {
 		return false
 	}
@@ -104,7 +114,10 @@ func (db *Database) GetPlayMode(ctx context.Context, chatID int64) bool {
 }
 
 // SetPlayMode sets the play mode for a given chat.
-func (db *Database) SetPlayMode(ctx context.Context, chatID int64, adminPlay bool) error {
+func (db *Database) SetPlayMode(chatID int64, adminPlay bool) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.chatDB.UpdateOne(ctx, bson.M{"_id": chatID}, bson.M{"$set": bson.M{"admin_play": adminPlay}}, options.UpdateOne().SetUpsert(true))
 	if err == nil {
 		db.chatCache.Delete(toKey(chatID))
@@ -113,16 +126,19 @@ func (db *Database) SetPlayMode(ctx context.Context, chatID int64, adminPlay boo
 }
 
 // GetAdminMode retrieves the admin mode for a chat.
-func (db *Database) GetAdminMode(ctx context.Context, chatID int64) string {
-	chat, _ := db.getChat(ctx, chatID)
+func (db *Database) GetAdminMode(chatID int64) string {
+	chat, _ := db.getChat(chatID)
 	if chat == nil || chat.AdminMode == "" {
-		return "everyone"
+		return utils.Everyone
 	}
 	return chat.AdminMode
 }
 
 // SetAdminMode sets the admin mode for a given chat.
-func (db *Database) SetAdminMode(ctx context.Context, chatID int64, adminMode string) error {
+func (db *Database) SetAdminMode(chatID int64, adminMode string) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.chatDB.UpdateOne(ctx, bson.M{"_id": chatID}, bson.M{"$set": bson.M{"admin_mode": adminMode}}, options.UpdateOne().SetUpsert(true))
 	if err == nil {
 		db.chatCache.Delete(toKey(chatID))
@@ -131,8 +147,8 @@ func (db *Database) SetAdminMode(ctx context.Context, chatID int64, adminMode st
 }
 
 // GetCmdDelete retrieves the command delete setting for a chat.
-func (db *Database) GetCmdDelete(ctx context.Context, chatID int64) bool {
-	chat, _ := db.getChat(ctx, chatID)
+func (db *Database) GetCmdDelete(chatID int64) bool {
+	chat, _ := db.getChat(chatID)
 	if chat == nil {
 		return false
 	}
@@ -140,7 +156,10 @@ func (db *Database) GetCmdDelete(ctx context.Context, chatID int64) bool {
 }
 
 // SetCmdDelete sets the command delete setting for a given chat.
-func (db *Database) SetCmdDelete(ctx context.Context, chatID int64, cmdDelete bool) error {
+func (db *Database) SetCmdDelete(chatID int64, cmdDelete bool) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.chatDB.UpdateOne(ctx, bson.M{"_id": chatID}, bson.M{"$set": bson.M{"cmd_delete": cmdDelete}}, options.UpdateOne().SetUpsert(true))
 	if err == nil {
 		db.chatCache.Delete(toKey(chatID))
@@ -149,7 +168,10 @@ func (db *Database) SetCmdDelete(ctx context.Context, chatID int64, cmdDelete bo
 }
 
 // GetAllChats retrieves a list of all chat IDs from the database.
-func (db *Database) GetAllChats(ctx context.Context) ([]int64, error) {
+func (db *Database) GetAllChats() ([]int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	cursor, err := db.chatDB.Find(ctx, bson.M{})
 	if err != nil {
 		return nil, err

--- a/src/core/db/lang.go
+++ b/src/core/db/lang.go
@@ -18,11 +18,15 @@ import (
 )
 
 // GetLanguage retrieves the language code for a chat.
-func (db *Database) GetLanguage(ctx context.Context, chatID int64) (string, error) {
+func (db *Database) GetLanguage(chatID int64) (string, error) {
 	key := toKey(chatID)
 	if cached, ok := db.langCache.Get(key); ok {
 		return cached, nil
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	var doc struct {
 		Lang string `bson:"lang"`
 	}
@@ -44,6 +48,7 @@ func (db *Database) SetLanguage(ctx context.Context, chatID int64, langCode stri
 		bson.M{"$set": bson.M{"lang": langCode}},
 		options.UpdateOne().SetUpsert(true),
 	)
+
 	if err == nil {
 		db.langCache.Set(toKey(chatID), langCode)
 	}

--- a/src/core/db/logger.go
+++ b/src/core/db/logger.go
@@ -9,17 +9,19 @@
 package db
 
 import (
-	"context"
-
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // GetLoggerStatus retrieves the logger status for a given bot.
-func (db *Database) GetLoggerStatus(ctx context.Context, _ int64) bool {
+func (db *Database) GetLoggerStatus() bool {
 	if cached, ok := db.loggerCache.Get("logger"); ok {
 		return cached
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	var doc struct {
 		Status bool `bson:"status"`
 	}
@@ -32,7 +34,9 @@ func (db *Database) GetLoggerStatus(ctx context.Context, _ int64) bool {
 }
 
 // SetLoggerStatus enables or disables the logger for a bot.
-func (db *Database) SetLoggerStatus(ctx context.Context, _ int64, status bool) error {
+func (db *Database) SetLoggerStatus(status bool) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
 	_, err := db.cacheDB.UpdateOne(ctx,
 		bson.M{"_id": "logger"},
 		bson.M{"$set": bson.M{"status": status}},

--- a/src/core/db/mongo.go
+++ b/src/core/db/mongo.go
@@ -47,7 +47,10 @@ type Database struct {
 var Instance *Database
 
 // InitDatabase initializes the database connection and sets up the global instance.
-func InitDatabase(ctx context.Context) error {
+func InitDatabase() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	opts := options.Client().ApplyURI(config.Conf.MongoUri).
 		SetMinPoolSize(10).
 		SetMaxConnIdleTime(10 * time.Minute).
@@ -89,7 +92,14 @@ func InitDatabase(ctx context.Context) error {
 }
 
 // Close gracefully closes the database connection.
-func (db *Database) Close(ctx context.Context) error {
+func (db *Database) Close() error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	slog.Info("[DB] Closing the database connection...")
 	return db.client.Disconnect(ctx)
+}
+
+func (db *Database) ctx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
 }

--- a/src/core/db/playlist.go
+++ b/src/core/db/playlist.go
@@ -43,7 +43,10 @@ func generateUniquePlaylistID() string {
 }
 
 // CreatePlaylist creates a new playlist for a user.
-func (db *Database) CreatePlaylist(ctx context.Context, name string, userID int64) (string, error) {
+func (db *Database) CreatePlaylist(name string, userID int64) (string, error) {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	id := generateUniquePlaylistID()
 	playlist := Playlist{
 		ID:     id,
@@ -59,7 +62,10 @@ func (db *Database) CreatePlaylist(ctx context.Context, name string, userID int6
 }
 
 // GetPlaylist retrieves a playlist by its ID.
-func (db *Database) GetPlaylist(ctx context.Context, id string) (*Playlist, error) {
+func (db *Database) GetPlaylist(id string) (*Playlist, error) {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	var playlist Playlist
 	err := db.playlistDB.FindOne(ctx, bson.M{"_id": id}).Decode(&playlist)
 	if err != nil {
@@ -69,17 +75,24 @@ func (db *Database) GetPlaylist(ctx context.Context, id string) (*Playlist, erro
 }
 
 // DeletePlaylist deletes a playlist by its ID.
-func (db *Database) DeletePlaylist(ctx context.Context, id string, userID int64) error {
+func (db *Database) DeletePlaylist(id string, userID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.playlistDB.DeleteOne(ctx, bson.M{"_id": id, "user_id": userID})
 	return err
 }
 
-func (db *Database) songExists(ctx context.Context, id string, trackID string) bool {
+func (db *Database) songExists(id string, trackID string) bool {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	var playlist Playlist
 	err := db.playlistDB.FindOne(ctx, bson.M{"_id": id}).Decode(&playlist)
 	if err != nil {
 		return false
 	}
+
 	for _, song := range playlist.Songs {
 		if song.TrackID == trackID {
 			return true
@@ -89,10 +102,13 @@ func (db *Database) songExists(ctx context.Context, id string, trackID string) b
 }
 
 // AddSongToPlaylist adds a song to a playlist.
-func (db *Database) AddSongToPlaylist(ctx context.Context, id string, song Song) error {
-	if db.songExists(ctx, id, song.TrackID) {
+func (db *Database) AddSongToPlaylist(id string, song Song) error {
+	if db.songExists(id, song.TrackID) {
 		return nil
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
 
 	_, err := db.playlistDB.UpdateOne(
 		ctx,
@@ -103,10 +119,13 @@ func (db *Database) AddSongToPlaylist(ctx context.Context, id string, song Song)
 }
 
 // RemoveSongFromPlaylist removes a song from a playlist by its track ID.
-func (db *Database) RemoveSongFromPlaylist(ctx context.Context, id string, trackID string) error {
-	if !db.songExists(ctx, id, trackID) {
+func (db *Database) RemoveSongFromPlaylist(id string, trackID string) error {
+	if !db.songExists(id, trackID) {
 		return fmt.Errorf("track with ID %s not found in playlist", trackID)
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
 
 	_, err := db.playlistDB.UpdateOne(
 		ctx,
@@ -122,7 +141,10 @@ func (db *Database) RemoveSongFromPlaylist(ctx context.Context, id string, track
 }
 
 // GetUserPlaylists retrieves all playlists for a user.
-func (db *Database) GetUserPlaylists(ctx context.Context, userID int64) ([]Playlist, error) {
+func (db *Database) GetUserPlaylists(userID int64) ([]Playlist, error) {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	var playlists []Playlist
 	cursor, err := db.playlistDB.Find(ctx, bson.M{"user_id": userID})
 	if err != nil {

--- a/src/core/db/users.go
+++ b/src/core/db/users.go
@@ -11,6 +11,7 @@ package db
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -23,11 +24,14 @@ type Users struct {
 }
 
 // AddUser adds a new user to the database if they do not already exist.
-func (db *Database) AddUser(ctx context.Context, userID int64) error {
+func (db *Database) AddUser(userID int64) error {
 	key := toKey(userID)
 	if _, ok := db.userCache.Get(key); ok {
 		return nil
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
 
 	_, err := db.userDB.UpdateOne(ctx,
 		bson.M{"_id": userID},
@@ -43,22 +47,28 @@ func (db *Database) AddUser(ctx context.Context, userID int64) error {
 }
 
 // RemoveUser removes a user from the database and cache.
-func (db *Database) RemoveUser(ctx context.Context, userID int64) error {
-	key := toKey(userID)
+func (db *Database) RemoveUser(userID int64) error {
+	ctx, cancel := db.ctx()
+	defer cancel()
+
 	_, err := db.userDB.DeleteOne(ctx, bson.M{"_id": userID})
 	if err != nil {
 		return err
 	}
-	db.userCache.Delete(key)
+
+	db.userCache.Delete(toKey(userID))
 	return nil
 }
 
 // IsUserExist checks if a user exists in the database.
-func (db *Database) IsUserExist(ctx context.Context, userID int64) (bool, error) {
+func (db *Database) IsUserExist(userID int64) (bool, error) {
 	key := toKey(userID)
 	if _, ok := db.userCache.Get(key); ok {
 		return true, nil
 	}
+
+	ctx, cancel := db.ctx()
+	defer cancel()
 
 	var user Users
 	err := db.userDB.FindOne(ctx, bson.M{"_id": userID}).Decode(&user)
@@ -73,7 +83,10 @@ func (db *Database) IsUserExist(ctx context.Context, userID int64) (bool, error)
 }
 
 // GetAllUsers retrieves a list of all user IDs from the database.
-func (db *Database) GetAllUsers(ctx context.Context) ([]int64, error) {
+func (db *Database) GetAllUsers() ([]int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	cursor, err := db.userDB.Find(ctx, bson.M{})
 	if err != nil {
 		return nil, err

--- a/src/core/db/utilities.go
+++ b/src/core/db/utilities.go
@@ -9,12 +9,8 @@
 package db
 
 import (
-	"context"
 	"fmt"
-	"time"
 )
-
-var ctxBg = context.Background()
 
 // toKey converts an int64 ID into a string format suitable for use as a cache key.
 func toKey(id int64) string {
@@ -30,21 +26,4 @@ func contains(list []int64, id int64) bool {
 		}
 	}
 	return false
-}
-
-// remove creates a new slice that excludes a specific ID from the original int64 slice.
-func remove(list []int64, id int64) []int64 {
-	var newList []int64
-	for _, v := range list {
-		if v != id {
-			newList = append(newList, v)
-		}
-	}
-	return newList
-}
-
-// Ctx creates a new context with a default timeout of 10 seconds.
-// It returns the context and a cancel function to release resources.
-func Ctx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(ctxBg, 10*time.Second)
 }

--- a/src/core/dl/api.go
+++ b/src/core/dl/api.go
@@ -9,6 +9,8 @@
 package dl
 
 import (
+	"time"
+
 	"ashokshau/tgmusic/config"
 	"ashokshau/tgmusic/src/utils"
 	"context"
@@ -22,8 +24,8 @@ import (
 	"strings"
 )
 
-// ApiData provides a unified interface for fetching track and playlist information from various music platforms via an API gateway.
-type ApiData struct {
+// apiData provides a unified interface for fetching track and playlist information from various music platforms via an API gateway.
+type apiData struct {
 	Query    string
 	ApiUrl   string
 	APIKey   string
@@ -38,11 +40,12 @@ var apiPatterns = map[string]*regexp.Regexp{
 	utils.SoundCloud: regexp.MustCompile(`(?i)^(https?://)?(www\.)?soundcloud\.com/[a-zA-Z0-9_-]+/(sets/)?[a-zA-Z0-9._-]+(\?.*)?$`),
 	utils.Gaana:      regexp.MustCompile(`(?i)https?:\/\/(?:www\.)?gaana\.com\/(song|album|playlist|artist)\/([A-Za-z0-9\-]+)`),
 	utils.Tidal:      regexp.MustCompile(`(?i)https?:\/\/(?:www\.|listen\.)?tidal\.com\/(?:browse\/)?(track|album|playlist)\/([a-zA-Z0-9-]+)(?:[\/?].*)?`),
+	utils.MXPlayer:   regexp.MustCompile(`(?i)https?:\/\/(?:www\.)?mxplayer\.in\/(?:show|movie)\/.*`),
 }
 
-// NewApiData creates and initializes a new ApiData instance with the provided query.
-func NewApiData(query string) *ApiData {
-	return &ApiData{
+// newApiData creates and initializes a new apiData instance with the provided query.
+func newApiData(query string) *apiData {
+	return &apiData{
 		Query:    strings.TrimSpace(query),
 		ApiUrl:   strings.TrimRight(config.Conf.ApiUrl, "/"),
 		APIKey:   config.Conf.ApiKey,
@@ -50,8 +53,7 @@ func NewApiData(query string) *ApiData {
 	}
 }
 
-// IsValid checks if the query is a valid URL for any of the supported platforms.
-func (a *ApiData) IsValid() bool {
+func (a *apiData) isValid() bool {
 	if a.Query == "" || a.ApiUrl == "" || a.APIKey == "" {
 		return false
 	}
@@ -64,14 +66,14 @@ func (a *ApiData) IsValid() bool {
 	return false
 }
 
-// GetInfo retrieves metadata for a track or playlist from the API.
-func (a *ApiData) GetInfo(ctx context.Context) (utils.PlatformTracks, error) {
-	if !a.IsValid() {
+// getInfo retrieves metadata for a track or playlist from the API.
+func (a *apiData) getInfo() (utils.PlatformTracks, error) {
+	if !a.isValid() {
 		return utils.PlatformTracks{}, errors.New("the provided URL is invalid or the platform is not supported")
 	}
 
 	fullURL := fmt.Sprintf("%s/api/get_url?%s", a.ApiUrl, url.Values{"url": {a.Query}}.Encode())
-	resp, err := sendRequest(ctx, http.MethodGet, fullURL, nil, map[string]string{"X-API-Key": a.APIKey})
+	resp, err := sendRequest(http.MethodGet, fullURL, nil, map[string]string{"X-API-Key": a.APIKey})
 	if err != nil {
 		return utils.PlatformTracks{}, fmt.Errorf("the GetInfo request failed: %w", err)
 	}
@@ -91,11 +93,14 @@ func (a *ApiData) GetInfo(ctx context.Context) (utils.PlatformTracks, error) {
 	return data, nil
 }
 
-// Search queries the API for a track. The context can be used for timeouts or cancellations.
-func (a *ApiData) Search(ctx context.Context) (utils.PlatformTracks, error) {
-	if a.IsValid() {
-		return a.GetInfo(ctx)
+// search queries the API for a track.
+func (a *apiData) search() (utils.PlatformTracks, error) {
+	if a.isValid() {
+		return a.getInfo()
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
 
 	fullURL := fmt.Sprintf("%s/api/search?%s", a.ApiUrl, url.Values{
 		"query": {a.Query},
@@ -127,13 +132,14 @@ func (a *ApiData) Search(ctx context.Context) (utils.PlatformTracks, error) {
 	return data, nil
 }
 
-// GetTrack retrieves detailed information for a single track from the API.
-func (a *ApiData) GetTrack(ctx context.Context) (utils.TrackInfo, error) {
+// getTrack retrieves detailed information for a single track from the API.
+func (a *apiData) getTrack() (utils.TrackInfo, error) {
 	fullURL := fmt.Sprintf("%s/api/track?%s", a.ApiUrl, url.Values{"url": {a.Query}}.Encode())
-	resp, err := sendRequest(ctx, http.MethodGet, fullURL, nil, map[string]string{"X-API-Key": a.APIKey})
+	resp, err := sendRequest(http.MethodGet, fullURL, nil, map[string]string{"X-API-Key": a.APIKey})
 	if err != nil {
 		return utils.TrackInfo{}, fmt.Errorf("the GetTrack request failed: %w", err)
 	}
+
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 	}(resp.Body)
@@ -146,17 +152,19 @@ func (a *ApiData) GetTrack(ctx context.Context) (utils.TrackInfo, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return utils.TrackInfo{}, fmt.Errorf("failed to decode the GetTrack response: %w", err)
 	}
+
 	return data, nil
 }
 
 // downloadTrack downloads a track using the API. If the track is a YouTube video and video format is requested,
-func (a *ApiData) downloadTrack(ctx context.Context, info utils.TrackInfo, video bool) (string, error) {
-	yt := NewYouTubeData(a.Query)
+func (a *apiData) downloadTrack(info utils.TrackInfo, video bool) (string, error) {
+	// if the track is from YouTube and video:true
+	yt := newYouTubeData(a.Query)
 	if info.Platform == utils.YouTube && video {
-		return yt.downloadTrack(ctx, info, video)
+		return yt.downloadTrack(info, video)
 	}
 
-	downloader, err := NewDownload(ctx, info)
+	downloader, err := newDownload(info)
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize the download: %w", err)
 	}
@@ -164,13 +172,13 @@ func (a *ApiData) downloadTrack(ctx context.Context, info utils.TrackInfo, video
 	filePath, err := downloader.Process()
 	if err != nil {
 		if info.Platform == utils.YouTube {
-			return yt.downloadTrack(ctx, info, video)
+			return yt.downloadTrack(info, video)
 		}
 		return "", fmt.Errorf("the download process failed: %w", err)
 	}
 
 	if strings.Contains(a.ApiUrl, filePath) {
-		return DownloadFile(filePath, "", false)
+		return downloadFile(filePath, "", false)
 	}
 
 	return filePath, nil

--- a/src/core/dl/direct_link.go
+++ b/src/core/dl/direct_link.go
@@ -9,6 +9,8 @@
 package dl
 
 import (
+	"time"
+
 	"ashokshau/tgmusic/src/utils"
 	"context"
 	"encoding/json"
@@ -20,29 +22,32 @@ import (
 	"strings"
 )
 
-type DirectLink struct {
-	Query string
+type directLink struct {
+	query string
 }
 
-func NewDirectLink(query string) *DirectLink {
-	return &DirectLink{Query: query}
+func newDirectLink(query string) *directLink {
+	return &directLink{query: query}
 }
 
-// IsValid checks if the query looks like a valid URL.
-func (d *DirectLink) IsValid() bool {
-	return strings.HasPrefix(d.Query, "http://") || strings.HasPrefix(d.Query, "https://")
+// ssValid checks if the query looks like a valid URL.
+func (d *directLink) isValid() bool {
+	return strings.HasPrefix(d.query, "http://") || strings.HasPrefix(d.query, "https://")
 }
 
-func (d *DirectLink) GetInfo(ctx context.Context) (utils.PlatformTracks, error) {
-	if !d.IsValid() {
+func (d *directLink) getInfo() (utils.PlatformTracks, error) {
+	if !d.isValid() {
 		return utils.PlatformTracks{}, errors.New("invalid url")
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "ffprobe",
 		"-v", "quiet",
 		"-print_format", "json",
 		"-show_format",
-		d.Query,
+		d.query,
 	)
 
 	output, err := cmd.Output()
@@ -64,7 +69,7 @@ func (d *DirectLink) GetInfo(ctx context.Context) (utils.PlatformTracks, error) 
 
 	title := info.Format.Tags.Title
 	if title == "" {
-		parts := strings.Split(d.Query, "/")
+		parts := strings.Split(d.query, "/")
 		if len(parts) > 0 {
 			title = parts[len(parts)-1]
 			title = strings.SplitN(title, "?", 2)[0]
@@ -84,20 +89,20 @@ func (d *DirectLink) GetInfo(ctx context.Context) (utils.PlatformTracks, error) 
 	track := utils.MusicTrack{
 		Title:    title,
 		Duration: duration,
-		Url:      d.Query,
-		Id:       d.Query,
+		Url:      d.query,
+		Id:       d.query,
 		Platform: utils.DirectLink,
 	}
 
 	return utils.PlatformTracks{Results: []utils.MusicTrack{track}}, nil
 }
 
-func (d *DirectLink) Search(ctx context.Context) (utils.PlatformTracks, error) {
-	return d.GetInfo(ctx)
+func (d *directLink) search() (utils.PlatformTracks, error) {
+	return d.getInfo()
 }
 
-func (d *DirectLink) GetTrack(ctx context.Context) (utils.TrackInfo, error) {
-	info, err := d.GetInfo(ctx)
+func (d *directLink) getTrack() (utils.TrackInfo, error) {
+	info, err := d.getInfo()
 	if err != nil {
 		return utils.TrackInfo{}, err
 	}
@@ -106,13 +111,15 @@ func (d *DirectLink) GetTrack(ctx context.Context) (utils.TrackInfo, error) {
 		return utils.TrackInfo{}, errors.New("no track found")
 	}
 
+	track := info.Results[0]
 	return utils.TrackInfo{
-		URL:      d.Query,
-		Platform: utils.DirectLink,
-		CdnURL:   d.Query,
+		Id:       track.Id,
+		URL:      track.Url,
+		CdnURL:   track.Url,
+		Platform: track.Platform,
 	}, nil
 }
 
-func (d *DirectLink) downloadTrack(_ context.Context, _ utils.TrackInfo, _ bool) (string, error) {
-	return d.Query, nil
+func (d *directLink) downloadTrack(_ utils.TrackInfo, _ bool) (string, error) {
+	return d.query, nil
 }

--- a/src/core/dl/downloader.go
+++ b/src/core/dl/downloader.go
@@ -10,19 +10,12 @@ package dl
 
 import (
 	"ashokshau/tgmusic/src/utils"
-	"context"
 	"fmt"
-	"os"
 
 	td "github.com/AshokShau/gotdbot"
 )
 
-func exists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-func DownloadSong(ctx context.Context, cached *utils.CachedTrack, bot *td.Client) (string, error) {
+func DownloadCachedTrack(cached *utils.CachedTrack, bot *td.Client) (string, error) {
 	if cached.Platform == utils.DirectLink {
 		return cached.URL, nil
 	}
@@ -31,21 +24,21 @@ func DownloadSong(ctx context.Context, cached *utils.CachedTrack, bot *td.Client
 		return downloadTelegramFile(cached, bot)
 	}
 
-	return downloadViaWrapper(ctx, cached, bot)
+	return downloadViaWrapper(cached, bot)
 }
 
-func downloadViaWrapper(ctx context.Context, cached *utils.CachedTrack, bot *td.Client) (string, error) {
+func downloadViaWrapper(cached *utils.CachedTrack, bot *td.Client) (string, error) {
 	wrapper := NewDownloaderWrapper(cached.URL)
 	if !wrapper.IsValid() {
 		return "", fmt.Errorf("invalid cached URL: %s", cached.URL)
 	}
 
-	track, err := wrapper.GetTrack(ctx)
+	track, err := wrapper.GetTrack()
 	if err != nil {
 		return "", fmt.Errorf("get track info: %w", err)
 	}
 
-	path, err := wrapper.DownloadTrack(ctx, track, cached.IsVideo)
+	path, err := wrapper.DownloadTrack(track, cached.IsVideo)
 	if err != nil {
 		return "", err
 	}

--- a/src/core/dl/helpers.go
+++ b/src/core/dl/helpers.go
@@ -10,7 +10,6 @@ package dl
 
 import (
 	"ashokshau/tgmusic/src/utils"
-	"context"
 	"errors"
 	"net/url"
 	"regexp"
@@ -27,23 +26,22 @@ var (
 	errMissingCDNURL = errors.New("missing cdn url")
 )
 
-// Download encapsulates the information and context required for a download operation.
-type Download struct {
+// download encapsulates the information and context required for a download operation.
+type download struct {
 	Track utils.TrackInfo
-	ctx   context.Context
 }
 
-// NewDownload creates and validates a new Download instance.
-func NewDownload(ctx context.Context, track utils.TrackInfo) (*Download, error) {
+// newDownload creates and validates a new download instance.
+func newDownload(track utils.TrackInfo) (*download, error) {
 	if track.CdnURL == "" {
 		return nil, errors.New("the CDN URL is missing")
 	}
 
-	return &Download{Track: track, ctx: ctx}, nil
+	return &download{Track: track}, nil
 }
 
 // Process initiates the download process based on the track's platform.
-func (d *Download) Process() (string, error) {
+func (d *download) Process() (string, error) {
 	switch {
 	case d.Track.CdnURL == "":
 		return "", errMissingCDNURL
@@ -57,7 +55,7 @@ func (d *Download) Process() (string, error) {
 }
 
 // processDirectDL manages direct downloads and includes improved error handling.
-func (d *Download) processDirectDL() (string, error) {
+func (d *download) processDirectDL() (string, error) {
 	// No need to download (ntgcalls can play with url)
 	return d.Track.CdnURL, nil
 }

--- a/src/core/dl/http_client.go
+++ b/src/core/dl/http_client.go
@@ -65,7 +65,10 @@ var client = &http.Client{
 }
 
 // sendRequest performs an HTTP request with a given context, method, URL, body, and headers.
-func sendRequest(ctx context.Context, method, fullURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
+func sendRequest(method, fullURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, method, fullURL, body)
 	if err != nil {
 		slog.Info("Error creating request", "error", err)
@@ -99,7 +102,7 @@ func sendRequest(ctx context.Context, method, fullURL string, body io.Reader, he
 			}
 			reqErr = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 		} else if isTemporaryError(reqErr) {
-			slog.Info("Temporary error on attempt /", "arg1", attempt+1, "arg2", maxRetries, "error", reqErr)
+			slog.Info("Temporary error on", "attempt", attempt+1, "maxRetries", maxRetries, "error", reqErr)
 			continue // Retry on temporary errors
 		} else {
 			break // Do not retry on permanent errors
@@ -161,8 +164,8 @@ func writeToFile(filename string, data io.Reader) error {
 	return nil
 }
 
-// DownloadFile downloads a file from a URL and saves it to a local path.
-func DownloadFile(urlStr, fileName string, overwrite bool) (string, error) {
+// downloadFile downloads a file from a URL and saves it to a local path.
+func downloadFile(urlStr, fileName string, overwrite bool) (string, error) {
 	if urlStr == "" {
 		return "", errors.New("an empty URL was provided")
 	}

--- a/src/core/dl/service.go
+++ b/src/core/dl/service.go
@@ -11,41 +11,40 @@ package dl
 import (
 	"ashokshau/tgmusic/config"
 	"ashokshau/tgmusic/src/utils"
-	"context"
 )
 
-// MusicService defines a standard interface for interacting with various music services.
+// musicService defines a standard interface for interacting with various music services.
 // This allows for a unified approach to handling different platforms like YouTube, Spotify, etc.
-type MusicService interface {
-	// IsValid determines if the service can handle the given query.
-	IsValid() bool
-	// GetInfo retrieves metadata for a track or playlist.
-	GetInfo(ctx context.Context) (utils.PlatformTracks, error)
-	// Search queries the service for a track.
-	Search(ctx context.Context) (utils.PlatformTracks, error)
-	// GetTrack fetches detailed information for a single track.
-	GetTrack(ctx context.Context) (utils.TrackInfo, error)
+type musicService interface {
+	// isValid determines if the service can handle the given query.
+	isValid() bool
+	// getInfo retrieves metadata for a track or playlist.
+	getInfo() (utils.PlatformTracks, error)
+	// search queries the service for a track.
+	search() (utils.PlatformTracks, error)
+	// getTrack fetches detailed information for a single track.
+	getTrack() (utils.TrackInfo, error)
 	// downloadTrack handles the download of a track.
-	downloadTrack(ctx context.Context, trackInfo utils.TrackInfo, video bool) (string, error)
+	downloadTrack(trackInfo utils.TrackInfo, video bool) (string, error)
 }
 
-// DownloaderWrapper provides a unified interface for music service interactions,
+// DownloaderWrapper provides a unified interface for music service interactions.
 type DownloaderWrapper struct {
-	Query   string
-	Service MusicService
+	service musicService
 }
 
-// NewDownloaderWrapper selects the appropriate MusicService based on the query format or configuration defaults.
+// NewDownloaderWrapper selects the appropriate musicService based on the query format or configuration defaults.
 func NewDownloaderWrapper(query string) *DownloaderWrapper {
-	yt := NewYouTubeData(query)
-	api := NewApiData(query)
-	direct := NewDirectLink(query)
-	var chosen MusicService
-	if yt.IsValid() {
+	yt := newYouTubeData(query)
+	api := newApiData(query)
+	direct := newDirectLink(query)
+
+	var chosen musicService
+	if yt.isValid() {
 		chosen = yt
-	} else if api.IsValid() {
+	} else if api.isValid() {
 		chosen = api
-	} else if direct.IsValid() {
+	} else if direct.isValid() {
 		chosen = direct
 	} else {
 		switch config.Conf.DefaultService {
@@ -57,33 +56,32 @@ func NewDownloaderWrapper(query string) *DownloaderWrapper {
 	}
 
 	return &DownloaderWrapper{
-		Query:   query,
-		Service: chosen,
+		service: chosen,
 	}
 }
 
 // IsValid checks if the underlying service can handle the query.
 func (d *DownloaderWrapper) IsValid() bool {
-	return d.Service != nil && d.Service.IsValid()
+	return d.service != nil && d.service.isValid()
 }
 
 // GetInfo retrieves metadata by delegating the call to the wrapped service.
-func (d *DownloaderWrapper) GetInfo(ctx context.Context) (utils.PlatformTracks, error) {
-	return d.Service.GetInfo(ctx)
+func (d *DownloaderWrapper) GetInfo() (utils.PlatformTracks, error) {
+	return d.service.getInfo()
 }
 
 // Search performs a search by delegating the call to the wrapped service.
-func (d *DownloaderWrapper) Search(ctx context.Context) (utils.PlatformTracks, error) {
-	return d.Service.Search(ctx)
+func (d *DownloaderWrapper) Search() (utils.PlatformTracks, error) {
+	return d.service.search()
 }
 
 // GetTrack retrieves detailed track information by delegating the call to the wrapped service.
-func (d *DownloaderWrapper) GetTrack(ctx context.Context) (utils.TrackInfo, error) {
-	return d.Service.GetTrack(ctx)
+func (d *DownloaderWrapper) GetTrack() (utils.TrackInfo, error) {
+	return d.service.getTrack()
 }
 
 // DownloadTrack downloads a track by delegating the call to the wrapped service.
 // It returns the file path of the downloaded track or an error if the download fails.
-func (d *DownloaderWrapper) DownloadTrack(ctx context.Context, info utils.TrackInfo, video bool) (string, error) {
-	return d.Service.downloadTrack(ctx, info, video)
+func (d *DownloaderWrapper) DownloadTrack(info utils.TrackInfo, video bool) (string, error) {
+	return d.service.downloadTrack(info, video)
 }

--- a/src/core/dl/spotify_dl.go
+++ b/src/core/dl/spotify_dl.go
@@ -38,7 +38,7 @@ var (
 )
 
 // processSpotify manages the download and decryption of Spotify tracks.
-func (d *Download) processSpotify() (string, error) {
+func (d *download) processSpotify() (string, error) {
 	track := d.Track
 	downloadsDir := config.Conf.DownloadsDir
 	sanitizedTrackID := filepath.Base(track.Id)
@@ -79,11 +79,12 @@ func (d *Download) processSpotify() (string, error) {
 }
 
 // downloadAndDecrypt handles the download and decryption of a file.
-func (d *Download) downloadAndDecrypt(encryptedPath, decryptedPath string) error {
+func (d *download) downloadAndDecrypt(encryptedPath, decryptedPath string) error {
 	resp, err := http.Get(d.Track.CdnURL)
 	if err != nil {
 		return fmt.Errorf("failed to download the file: %w", err)
 	}
+
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 	}(resp.Body)
@@ -105,8 +106,8 @@ func (d *Download) downloadAndDecrypt(encryptedPath, decryptedPath string) error
 	if err != nil {
 		return fmt.Errorf("failed to decrypt the audio file: %w", err)
 	}
-	slog.Info("Decryption was completed in .", "duration", decryptTime)
 
+	slog.Info("Decryption was completed in .", "duration", decryptTime)
 	return os.WriteFile(decryptedPath, decryptedData, defaultFilePerm)
 }
 

--- a/src/core/dl/youtube.go
+++ b/src/core/dl/youtube.go
@@ -9,6 +9,8 @@
 package dl
 
 import (
+	"time"
+
 	"ashokshau/tgmusic/config"
 	"ashokshau/tgmusic/src/utils"
 	"context"
@@ -24,8 +26,8 @@ import (
 	"strings"
 )
 
-// YouTubeData provides an interface for fetching track and playlist information from YouTube.
-type YouTubeData struct {
+// youTubeData provides an interface for fetching track and playlist information from YouTube.
+type youTubeData struct {
 	Query    string
 	ApiUrl   string
 	APIKey   string
@@ -39,9 +41,9 @@ var youtubePatterns = map[string]*regexp.Regexp{
 	"yt_shorts": regexp.MustCompile(`(?i)^(?:https?://)?(?:www\.)?youtube\.com/shorts/.*`),
 }
 
-// NewYouTubeData initializes a YouTubeData instance with pre-compiled regex patterns and a cleaned query.
-func NewYouTubeData(query string) *YouTubeData {
-	return &YouTubeData{
+// newYouTubeData initializes a youTubeData instance with pre-compiled regex patterns and a cleaned query.
+func newYouTubeData(query string) *youTubeData {
+	return &youTubeData{
 		Query:    strings.TrimSpace(query),
 		ApiUrl:   strings.TrimRight(config.Conf.ApiUrl, "/"),
 		APIKey:   config.Conf.ApiKey,
@@ -49,8 +51,7 @@ func NewYouTubeData(query string) *YouTubeData {
 	}
 }
 
-// IsValid checks if the query string matches any of the known YouTube URL patterns.
-func (y *YouTubeData) IsValid() bool {
+func (y *youTubeData) isValid() bool {
 	if y.Query == "" {
 		slog.Info("The query or patterns are empty.")
 		return false
@@ -64,12 +65,13 @@ func (y *YouTubeData) IsValid() bool {
 	return false
 }
 
-// GetInfo retrieves metadata for a track from YouTube.
-// It returns a PlatformTracks object or an error if the information cannot be fetched.
-func (y *YouTubeData) GetInfo(ctx context.Context) (utils.PlatformTracks, error) {
-	if !y.IsValid() {
+func (y *youTubeData) getInfo() (utils.PlatformTracks, error) {
+	if !y.isValid() {
 		return utils.PlatformTracks{}, errors.New("the provided URL is invalid or the platform is not supported")
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
 
 	y.Query = normalizeYouTubeURL(y.Query)
 	videoID := extractVideoID(y.Query)
@@ -102,34 +104,35 @@ func (y *YouTubeData) GetInfo(ctx context.Context) (utils.PlatformTracks, error)
 	return utils.PlatformTracks{}, errors.New("no video or playlist results were found")
 }
 
-// Search performs a search for a track on YouTube.
-func (y *YouTubeData) Search(_ context.Context) (utils.PlatformTracks, error) {
+func (y *youTubeData) search() (utils.PlatformTracks, error) {
 	tracks, err := searchYouTube(y.Query, 5)
 	if err != nil {
 		return utils.PlatformTracks{}, err
 	}
+
 	if len(tracks) == 0 {
 		return utils.PlatformTracks{}, errors.New("no video results were found")
 	}
+
 	return utils.PlatformTracks{Results: tracks}, nil
 }
 
-// GetTrack retrieves detailed information for a single track.
-func (y *YouTubeData) GetTrack(ctx context.Context) (utils.TrackInfo, error) {
+func (y *youTubeData) getTrack() (utils.TrackInfo, error) {
 	if y.Query == "" {
 		return utils.TrackInfo{}, errors.New("the query is empty")
 	}
-	if !y.IsValid() {
+
+	if !y.isValid() {
 		return utils.TrackInfo{}, errors.New("the provided URL is invalid or the platform is not supported")
 	}
 
 	if y.ApiUrl != "" && y.APIKey != "" {
-		if trackInfo, err := NewApiData(y.Query).GetTrack(ctx); err == nil {
+		if trackInfo, err := newApiData(y.Query).getTrack(); err == nil {
 			return trackInfo, nil
 		}
 	}
 
-	getInfo, err := y.GetInfo(ctx)
+	getInfo, err := y.getInfo()
 	if err != nil {
 		return utils.TrackInfo{}, err
 	}
@@ -148,19 +151,19 @@ func (y *YouTubeData) GetTrack(ctx context.Context) (utils.TrackInfo, error) {
 }
 
 // downloadTrack handles the download of a track from YouTube.
-func (y *YouTubeData) downloadTrack(ctx context.Context, info utils.TrackInfo, video bool) (string, error) {
+func (y *youTubeData) downloadTrack(info utils.TrackInfo, video bool) (string, error) {
 	if !video && y.ApiUrl != "" && y.APIKey != "" {
-		if filePath, err := y.downloadWithApi(ctx, info.Id, video); err == nil {
+		if filePath, err := y.downloadWithApi(info.Id, video); err == nil {
 			return filePath, nil
 		}
 	}
 
-	filePath, err := y.downloadWithYtDlp(ctx, info.Id, video)
+	filePath, err := y.downloadWithYtDlp(info.Id, video)
 	return filePath, err
 }
 
 // buildYtdlpParams constructs the command-line parameters for yt-dlp to download media.
-func (y *YouTubeData) buildYtdlpParams(videoID string, video bool) []string {
+func (y *youTubeData) buildYtdlpParams(videoID string, video bool) []string {
 	outputTemplate := filepath.Join(config.Conf.DownloadsDir, "%(id)s.%(ext)s")
 
 	params := []string{
@@ -204,12 +207,16 @@ func (y *YouTubeData) buildYtdlpParams(videoID string, video bool) []string {
 }
 
 // downloadWithYtDlp downloads media from YouTube using the yt-dlp command-line tool.
-func (y *YouTubeData) downloadWithYtDlp(ctx context.Context, videoID string, video bool) (string, error) {
+func (y *youTubeData) downloadWithYtDlp(videoID string, video bool) (string, error) {
 	if videoID == "" {
 		return "", errors.New("videoID is empty")
 	}
 
 	ytdlpParams := y.buildYtdlpParams(videoID, video)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	cmd := exec.CommandContext(ctx, ytdlpParams[0], ytdlpParams[1:]...)
 
 	output, err := cmd.Output()
@@ -240,7 +247,7 @@ func (y *YouTubeData) downloadWithYtDlp(ctx context.Context, videoID string, vid
 }
 
 // getCookieFile retrieves the path to a cookie file from the configured list.
-func (y *YouTubeData) getCookieFile() string {
+func (y *youTubeData) getCookieFile() string {
 	cookiesPath := config.Conf.CookiesPath
 	if len(cookiesPath) == 0 {
 		return ""
@@ -255,15 +262,15 @@ func (y *YouTubeData) getCookieFile() string {
 }
 
 // downloadWithApi downloads a track using the external API.
-func (y *YouTubeData) downloadWithApi(ctx context.Context, videoID string, _ bool) (string, error) {
+func (y *youTubeData) downloadWithApi(videoID string, _ bool) (string, error) {
 	videoUrl := fmt.Sprintf("https://www.youtube.com/watch?v=%s", videoID)
-	api := NewApiData(videoUrl)
-	track, err := api.GetTrack(ctx)
+	api := newApiData(videoUrl)
+	track, err := api.getTrack()
 	if err != nil {
 		return "", err
 	}
 
-	down, err := NewDownload(ctx, track)
+	down, err := newDownload(track)
 	if err != nil {
 		slog.Info("Error creating download: " + err.Error())
 		return "", err

--- a/src/handlers/admins.go
+++ b/src/handlers/admins.go
@@ -23,7 +23,6 @@ const reloadCooldown = 3 * time.Minute
 
 var reloadRateLimit = cache.NewCache[time.Time](reloadCooldown)
 
-// reloadAdminCacheHandler reloads the admin cache for a chat.
 func reloadAdminCacheHandler(c *gotdbot.Client, ctx *gotdbot.Context) error {
 	m := ctx.EffectiveMessage
 	if m.IsPrivate() {
@@ -35,30 +34,31 @@ func reloadAdminCacheHandler(c *gotdbot.Client, ctx *gotdbot.Context) error {
 		timePassed := time.Since(lastUsed)
 		if timePassed < reloadCooldown {
 			remaining := int((reloadCooldown - timePassed).Seconds())
-			_, _ = m.ReplyText(c, fmt.Sprintf("⏳ Please wait %s before using this command again.", utils.SecToMin(remaining)), nil)
+			_, _ = m.ReplyText(c, fmt.Sprintf("Please wait %s before using this command again.", utils.SecToMin(remaining)), nil)
 			return nil
 		}
 	}
 
 	reloadRateLimit.Set(reloadKey, time.Now())
-	reply, err := m.ReplyText(c, "🔄 Reloading admin cache...", nil)
+
+	reply, err := m.ReplyText(c, "Reloading administrator cache...", nil)
 	if err != nil {
 		c.Logger.Warn("Failed to send reloading message for chat", "chat_id", m.ChatId, "error", err)
 		return gotdbot.EndGroups
 	}
 
 	cache.ClearAdminCache(m.ChatId)
-	// cache.ChatCache.ClearChat(m.ChatId)
 	vc.Calls.UpdateInviteLink(m.ChatId, "")
+
 	admins, err := cache.GetAdmins(c, m.ChatId, true)
 	if err != nil {
 		c.Logger.Warn("Failed to reload the admin cache for chat", "chat_id", m.ChatId, "error", err)
-		_, _ = reply.EditText(c, "⚠️ Error reloading admin cache.", nil)
+		_, _ = reply.EditText(c, "Failed to reload administrator cache.", nil)
 		return gotdbot.EndGroups
 	}
 
-	c.Logger.Info("Reloaded  admins for chat", "arg1", len(admins), "chat_id", m.ChatId)
-	_, _ = reply.EditText(c, "✅ Admin cache reloaded.", nil)
+	c.Logger.Info("Reloaded admins for chat", "count", len(admins), "chat_id", m.ChatId)
+	_, _ = reply.EditText(c, "Administrator cache reloaded successfully.", nil)
 	return gotdbot.EndGroups
 }
 

--- a/src/handlers/auth.go
+++ b/src/handlers/auth.go
@@ -10,37 +10,12 @@ package handlers
 
 import (
 	"ashokshau/tgmusic/src/core/cache"
-	"errors"
-	"fmt"
-
 	"ashokshau/tgmusic/src/core/db"
+	"fmt"
 
 	td "github.com/AshokShau/gotdbot"
 )
 
-// getTargetUserID gets the user ID from a message.
-func getTargetUserID(c *td.Client, m *td.Message) (int64, error) {
-	var userID int64
-	if m.ReplyToMessageID() != 0 {
-		replyMsg, err := m.GetRepliedMessage(c)
-		if err != nil {
-			return 0, err
-		}
-		userID = replyMsg.SenderID()
-	}
-
-	if userID == 0 {
-		return 0, errors.New("no user specified")
-	}
-
-	if m.SenderID() == userID {
-		return 0, errors.New("cannot perform action on yourself")
-	}
-
-	return userID, nil
-}
-
-// authListHandler handles the /auth command.
 func authListHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
@@ -52,25 +27,22 @@ func authListHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	chatID := m.ChatId
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
-	authUser := db.Instance.GetAuthUsers(ctx2, chatID)
+	authUser := db.Instance.GetAuthUsers(chatID)
 	if authUser == nil || len(authUser) == 0 {
-		_, _ = m.ReplyText(c, "ℹ️ No authorized users.", nil)
+		_, _ = m.ReplyText(c, "No authorized users found.", nil)
 		return nil
 	}
 
-	text := "<b>Authorized Users:</b>\n\n"
+	text := "<b>Authorized Users</b>\n\n"
 	for _, uid := range authUser {
 		text += fmt.Sprintf("• <a href=\"tg://user?id=%d\">%d</a>\n", uid, uid)
 	}
 
-	_, _ = m.ReplyText(c, text, &td.SendTextMessageOpts{ParseMode: "HTML"})
+	_, _ = m.ReplyText(c, text, replyOpts)
 	return td.EndGroups
 }
 
-// addAuthHandler handles the /addauth command.
 func addAuthHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
@@ -86,20 +58,16 @@ func addAuthHandler(c *td.Client, ctx *td.Context) error {
 	UserStatus, err := cache.GetUserAdmin(c, chatID, m.SenderID(), false)
 	if err != nil {
 		c.Logger.Warn("GetUserAdmin error", "error", err)
-		_, _ = m.ReplyText(c, "⚠️ Failed to get user admin status (cache or fetch failed).", nil)
+		_, _ = m.ReplyText(c, "Unable to verify administrator status.", nil)
 		return td.EndGroups
 	}
 
 	switch UserStatus.Status.(type) {
 	case *td.ChatMemberStatusCreator, *td.ChatMemberStatusAdministrator:
-		// User is an admin, proceed
 	default:
-		_, _ = m.ReplyText(c, "❌ You must be an admin to use this command.", nil)
+		_, _ = m.ReplyText(c, "You must be an administrator to use this command.", nil)
 		return td.EndGroups
 	}
-
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
 	userID, err := getTargetUserID(c, m)
 	if err != nil {
@@ -107,22 +75,21 @@ func addAuthHandler(c *td.Client, ctx *td.Context) error {
 		return nil
 	}
 
-	if db.Instance.IsAuthUser(ctx2, chatID, userID) {
-		_, _ = m.ReplyText(c, "User is already authorized.", nil)
+	if db.Instance.IsAuthUser(chatID, userID) {
+		_, _ = m.ReplyText(c, "This user is already authorized.", nil)
 		return nil
 	}
 
-	if err = db.Instance.AddAuthUser(ctx2, chatID, userID); err != nil {
+	if err = db.Instance.AddAuthUser(chatID, userID); err != nil {
 		c.Logger.Error("Failed to add authorized user", "error", err)
-		_, _ = m.ReplyText(c, "Error adding user.", nil)
+		_, _ = m.ReplyText(c, "Failed to authorize the user.", nil)
 		return nil
 	}
 
-	_, err = m.ReplyText(c, fmt.Sprintf("✅ User %d authorized.", userID), nil)
+	_, err = m.ReplyText(c, fmt.Sprintf("User %d has been authorized.", userID), nil)
 	return err
 }
 
-// removeAuthHandler handles the /removeauth command.
 func removeAuthHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
@@ -134,23 +101,20 @@ func removeAuthHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	chatID := m.ChatId
+
 	UserStatus, err := cache.GetUserAdmin(c, chatID, m.SenderID(), false)
 	if err != nil {
 		c.Logger.Warn("GetUserAdmin error", "error", err)
-		_, _ = m.ReplyText(c, "⚠️ Failed to get user admin status (cache or fetch failed).", nil)
+		_, _ = m.ReplyText(c, "Unable to verify administrator status.", nil)
 		return td.EndGroups
 	}
 
 	switch UserStatus.Status.(type) {
 	case *td.ChatMemberStatusCreator, *td.ChatMemberStatusAdministrator:
-		// User is an admin, proceed
 	default:
-		_, _ = m.ReplyText(c, "❌ You must be an admin to use this command.", nil)
+		_, _ = m.ReplyText(c, "You must be an administrator to use this command.", nil)
 		return td.EndGroups
 	}
-
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
 	userID, err := getTargetUserID(c, m)
 	if err != nil {
@@ -158,17 +122,17 @@ func removeAuthHandler(c *td.Client, ctx *td.Context) error {
 		return nil
 	}
 
-	if !db.Instance.IsAuthUser(ctx2, chatID, userID) {
-		_, _ = m.ReplyText(c, "User is not authorized.", nil)
+	if !db.Instance.IsAuthUser(chatID, userID) {
+		_, _ = m.ReplyText(c, "This user is not authorized.", nil)
 		return nil
 	}
 
-	if err := db.Instance.RemoveAuthUser(ctx2, chatID, userID); err != nil {
+	if err := db.Instance.RemoveAuthUser(chatID, userID); err != nil {
 		c.Logger.Error("Failed to remove authorized user", "error", err)
-		_, _ = m.ReplyText(c, "Error removing user.", nil)
+		_, _ = m.ReplyText(c, "Failed to remove authorized user.", nil)
 		return nil
 	}
 
-	_, err = m.ReplyText(c, fmt.Sprintf("✅ User %d removed from authorized list.", userID), nil)
+	_, err = m.ReplyText(c, fmt.Sprintf("User %d has been removed from the authorized list.", userID), nil)
 	return err
 }

--- a/src/handlers/broadcast.go
+++ b/src/handlers/broadcast.go
@@ -10,7 +10,6 @@ package handlers
 
 import (
 	"ashokshau/tgmusic/src/core/db"
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -49,9 +48,6 @@ func broadcastHandler(c *td.Client, ctx *td.Context) error {
 
 	broadcastInProgress.Store(true)
 	defer broadcastInProgress.Store(false)
-
-	ctx2, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	reply, err := m.GetRepliedMessage(c)
 	if err != nil {
@@ -98,8 +94,8 @@ func broadcastHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	broadcastCancelFlag.Store(false)
-	chats, _ := db.Instance.GetAllChats(ctx2)
-	users, _ := db.Instance.GetAllUsers(ctx2)
+	chats, _ := db.Instance.GetAllChats()
+	users, _ := db.Instance.GetAllUsers()
 
 	var targets []int64
 	if !noChats {
@@ -183,7 +179,7 @@ func broadcastHandler(c *td.Client, ctx *td.Context) error {
 			}
 
 			/*
-				if wait := td.GetFloodWait(errSend); wait > 0 {
+				if wait := getFloodWait(errSend); wait > 0 {
 					c.Logger.Warn("FloodWait s for chatID=", "arg1", wait, "id", item.ID)
 
 					if item.RetryCount < 2 {

--- a/src/handlers/callbacks.go
+++ b/src/handlers/callbacks.go
@@ -22,8 +22,6 @@ import (
 	td "github.com/AshokShau/gotdbot"
 )
 
-// playCallbackHandler handles callbacks from the play keyboard.
-// It returns an error if any.
 func playCallbackHandler(c *td.Client, ctx *td.Context) error {
 	cb := ctx.Update.UpdateNewCallbackQuery
 	if !adminModeCB(c, cb) {
@@ -41,26 +39,22 @@ func playCallbackHandler(c *td.Client, ctx *td.Context) error {
 		user = &td.User{FirstName: "Unknown", Id: cb.SenderUserId}
 	}
 
-	ctx2, cancel := db.Ctx()
-	defer cancel()
-
 	if !cache.ChatCache.IsActive(chatID) {
-		text := "⏸ No track currently playing."
-		_ = cb.Answer(c, 1, false, text, "")
-		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML"})
+		text := "There is no active playback."
+		_ = cb.Answer(c, 0, false, text, "")
+		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 	}
 
 	currentTrack := cache.ChatCache.GetPlayingTrack(chatID)
 	if currentTrack == nil {
-		_ = cb.Answer(c, 1, false, "⏸ No track currently playing.", "")
-		_, _ = cb.EditMessageText(c, "⏸ No track currently playing.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML"})
+		_ = cb.Answer(c, 0, false, "There is no active playback.", "")
+		_, _ = cb.EditMessageText(c, "There is no active playback.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 	}
 
 	buildTrackMessage := func(status, emoji string) string {
-		return fmt.Sprintf(
-			"%s <b>%s</b>\n\n🎧 <b>Track:</b> <a href='%s'>%s</a>\n🕒 <b>Duration:</b> %s\n🙋‍♂️ <b>Requested by:</b> %s",
+		return fmt.Sprintf("%s <b>%s</b>\n\n<b>Track:</b> <a href='%s'>%s</a>\n<b>Duration:</b> %s\n<b>Requested by:</b> %s",
 			emoji, status,
 			currentTrack.URL, currentTrack.Name,
 			utils.SecToMin(currentTrack.Duration),
@@ -71,82 +65,81 @@ func playCallbackHandler(c *td.Client, ctx *td.Context) error {
 	switch {
 	case strings.Contains(data, "play_skip"):
 		if err := vc.Calls.PlayNext(chatID); err != nil {
-			_ = cb.Answer(c, 1, false, "Failed to skip track.", "")
-			_, _ = cb.EditMessageText(c, "Failed to skip track.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML"})
+			_ = cb.Answer(c, 0, false, "Unable to skip the current track.", "")
+			_, _ = cb.EditMessageText(c, "Unable to skip the current track.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML", DisableWebPagePreview: true})
 			return nil
 		}
-		_ = cb.Answer(c, 1, false, "Track skipped.", "")
+		_ = cb.Answer(c, 0, false, "Track skipped.", "")
 		_ = c.DeleteMessages(chatID, []int64{cb.MessageId}, &td.DeleteMessagesOpts{Revoke: true})
 		return nil
 
 	case strings.Contains(data, "play_stop"):
 		if err := vc.Calls.Stop(chatID); err != nil {
-			_ = cb.Answer(c, 1, false, "Failed to stop track.", "")
-			_, _ = cb.EditMessageText(c, "Failed to stop track.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML"})
+			_ = cb.Answer(c, 0, false, "Unable to stop playback.", "")
+			_, _ = cb.EditMessageText(c, "Unable to stop playback.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML", DisableWebPagePreview: true})
 			return nil
 		}
-		msg := fmt.Sprintf("⏹ <b>Playback Stopped</b>\n└ Requested by: %s", user.FirstName)
-		_ = cb.Answer(c, 1, false, "Playback stopped.", "")
-		_, err := cb.EditMessageText(c, msg, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML"})
+		msg := fmt.Sprintf("<b>Playback stopped.</b>\nRequested by: %s", user.FirstName)
+		_ = cb.Answer(c, 0, false, "Playback stopped.", "")
+		_, err := cb.EditMessageText(c, msg, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML", DisableWebPagePreview: true})
 		return err
 
 	case strings.Contains(data, "play_pause"):
 		if _, err = vc.Calls.Pause(chatID); err != nil {
-			_ = cb.Answer(c, 1, false, "Failed to pause track.", "")
-			_, _ = cb.EditMessageText(c, "Failed to pause track.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML"})
+			_ = cb.Answer(c, 0, false, "Unable to pause playback.", "")
+			_, _ = cb.EditMessageText(c, "Unable to pause playback.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons(""), ParseMode: "HTML", DisableWebPagePreview: true})
 			return nil
 		}
-		_ = cb.Answer(c, 1, false, "Track paused.", "")
-		text := buildTrackMessage("Paused", "⏸") + fmt.Sprintf("\n\n⏸ <i>Paused by %s</i>", user.FirstName)
-		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("pause"), ParseMode: "HTML"})
+		_ = cb.Answer(c, 0, false, "Playback paused.", "")
+		text := buildTrackMessage("Paused", "⏸") + fmt.Sprintf("\n\nPaused by %s", user.FirstName)
+		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("pause"), ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 
 	case strings.Contains(data, "play_resume"):
 		if _, err := vc.Calls.Resume(chatID); err != nil {
-			_ = cb.Answer(c, 1, false, "Failed to resume track.", "")
-			_, _ = cb.EditMessageText(c, "Failed to resume track.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("pause"), ParseMode: "HTML"})
+			_ = cb.Answer(c, 0, false, "Unable to resume playback.", "")
+			_, _ = cb.EditMessageText(c, "Unable to resume playback.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("pause"), ParseMode: "HTML", DisableWebPagePreview: true})
 			return nil
 		}
-
-		_ = cb.Answer(c, 1, false, "Track resumed.", "")
-		text := buildTrackMessage("Now Playing", "🎵") + fmt.Sprintf("\n\n▶️ <i>Resumed by %s</i>", user.FirstName)
-		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("resume"), ParseMode: "HTML"})
+		_ = cb.Answer(c, 0, false, "Playback resumed.", "")
+		text := buildTrackMessage("Now Playing", "▶") + fmt.Sprintf("\n\nResumed by %s", user.FirstName)
+		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("resume"), ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 
 	case strings.Contains(data, "play_mute"):
 		if _, err := vc.Calls.Mute(chatID); err != nil {
-			_ = cb.Answer(c, 1, false, "Failed to mute track.", "")
-			_, _ = cb.EditMessageText(c, "Failed to mute track.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("mute"), ParseMode: "HTML"})
+			_ = cb.Answer(c, 0, false, "Unable to mute playback.", "")
+			_, _ = cb.EditMessageText(c, "Unable to mute playback.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("mute"), ParseMode: "HTML", DisableWebPagePreview: true})
 			return nil
 		}
-
-		_ = cb.Answer(c, 1, false, "Track muted.", "")
-		text := buildTrackMessage("Muted", "🔇") + fmt.Sprintf("\n\n🔇 <i>Muted by %s</i>", user.FirstName)
-		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("mute"), ParseMode: "HTML"})
+		_ = cb.Answer(c, 0, false, "Playback muted.", "")
+		text := buildTrackMessage("Muted", "🔇") + fmt.Sprintf("\n\nMuted by %s", user.FirstName)
+		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("mute"), ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 
 	case strings.Contains(data, "play_unmute"):
 		if _, err := vc.Calls.Unmute(chatID); err != nil {
-			_ = cb.Answer(c, 1, false, "Failed to unmute track.", "")
-			_, _ = cb.EditMessageText(c, "Failed to unmute track.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("unmute"), ParseMode: "HTML"})
+			_ = cb.Answer(c, 0, false, "Unable to unmute playback.", "")
+			_, _ = cb.EditMessageText(c, "Unable to unmute playback.", &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("unmute"), ParseMode: "HTML"})
 			return nil
 		}
-		_ = cb.Answer(c, 1, false, "Track unmuted.", "")
-		text := buildTrackMessage("Now Playing", "🎵") + fmt.Sprintf("\n\n🔊 <i>Unmuted by %s</i>", user.FirstName)
+		_ = cb.Answer(c, 0, false, "Playback unmuted.", "")
+		text := buildTrackMessage("Now Playing", "▶") + fmt.Sprintf("\n\nUnmuted by %s", user.FirstName)
 		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("unmute"), DisableWebPagePreview: true})
 		return nil
+
 	case strings.Contains(data, "play_add_to_list"):
-		playlists, err := db.Instance.GetUserPlaylists(ctx2, cb.SenderUserId)
+		playlists, err := db.Instance.GetUserPlaylists(cb.SenderUserId)
 		if err != nil {
-			_ = cb.Answer(c, 1, false, "An error occurred while fetching playlists.", "")
+			_ = cb.Answer(c, 0, false, "Unable to fetch playlists.", "")
 			return nil
 		}
 
 		var playlistID string
 		if len(playlists) == 0 {
-			playlistID, err = db.Instance.CreatePlaylist(ctx2, "My Playlist (TgMusic)", cb.SenderUserId)
+			playlistID, err = db.Instance.CreatePlaylist("My Playlist (TgMusic)", cb.SenderUserId)
 			if err != nil {
-				_ = cb.Answer(c, 1, false, "An error occurred while creating a new playlist.", "")
+				_ = cb.Answer(c, 0, false, "Unable to create playlist.", "")
 				return nil
 			}
 		} else {
@@ -161,34 +154,33 @@ func playCallbackHandler(c *td.Client, ctx *td.Context) error {
 			Platform: currentTrack.Platform,
 		}
 
-		err = db.Instance.AddSongToPlaylist(ctx2, playlistID, song)
+		err = db.Instance.AddSongToPlaylist(playlistID, song)
 		if err != nil {
-			_ = cb.Answer(c, 1, false, "An error occurred while adding the track to the playlist.", "")
+			_ = cb.Answer(c, 0, false, "Unable to add track to playlist.", "")
 			return nil
 		}
 
-		playlist, err := db.Instance.GetPlaylist(ctx2, playlistID)
+		playlist, err := db.Instance.GetPlaylist(playlistID)
 		if err != nil {
-			_ = cb.Answer(c, 1, false, "Playlist not found :)", "")
+			_ = cb.Answer(c, 0, false, "Playlist not found.", "")
 			return nil
 		}
 
-		_ = cb.Answer(c, 1, false, fmt.Sprintf("✅ '%s' has been added to the playlist '%s'.", song.Name, playlist.Name), "")
+		_ = cb.Answer(c, 0, false, fmt.Sprintf("Track \"%s\" added to playlist \"%s\".", song.Name, playlist.Name), "")
 		return nil
 	}
 
-	text := buildTrackMessage("Now Playing", "🎵")
+	text := buildTrackMessage("Now Playing", "▶")
 	_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("resume"), ParseMode: "HTML", DisableWebPagePreview: true})
 	return nil
 }
 
-// vcPlayHandler handles callbacks from the vcplay keyboard.
-// It returns an error if any.
 func vcPlayHandler(c *td.Client, ctx *td.Context) error {
 	cb := ctx.Update.UpdateNewCallbackQuery
 	data := cb.DataString()
+
 	if strings.Contains(data, "vcplay_close") {
-		_ = cb.Answer(c, 1, false, "Closing...", "")
+		_ = cb.Answer(c, 0, false, "Closing panel.", "")
 		_ = c.DeleteMessages(cb.ChatId, []int64{cb.MessageId}, &td.DeleteMessagesOpts{Revoke: true})
 		return nil
 	}

--- a/src/handlers/devs.go
+++ b/src/handlers/devs.go
@@ -82,10 +82,8 @@ func clearAssistantsHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	m := ctx.EffectiveMessage
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
-	done, err := db.Instance.ClearAllAssistants(ctx2)
+	done, err := db.Instance.ClearAllAssistants()
 	if err != nil {
 		_, _ = m.ReplyText(c, fmt.Sprintf("failed to clear assistants: %s", err.Error()), nil)
 		return td.EndGroups
@@ -124,14 +122,13 @@ func loggerHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	m := ctx.EffectiveMessage
-	ctx2, cancel := db.Ctx()
-	defer cancel()
+
 	if config.Conf.LoggerId == 0 {
 		_, _ = m.ReplyText(c, "Please set LOGGER_ID in .env first.", nil)
 		return td.EndGroups
 	}
 
-	loggerStatus := db.Instance.GetLoggerStatus(ctx2, c.Me.Id)
+	loggerStatus := db.Instance.GetLoggerStatus()
 	args := strings.ToLower(Args(m))
 	if len(args) == 0 {
 		_, _ = m.ReplyText(c, fmt.Sprintf("Usage: /logger [enable|disable|on|off]\nCurrent status: %t", loggerStatus), nil)
@@ -140,10 +137,10 @@ func loggerHandler(c *td.Client, ctx *td.Context) error {
 
 	switch args {
 	case "enable", "on":
-		_ = db.Instance.SetLoggerStatus(ctx2, c.Me.Id, true)
+		_ = db.Instance.SetLoggerStatus(true)
 		_, _ = m.ReplyText(c, "Logger Enabled", nil)
 	case "disable", "off":
-		_ = db.Instance.SetLoggerStatus(ctx2, c.Me.Id, false)
+		_ = db.Instance.SetLoggerStatus(false)
 		_, _ = m.ReplyText(c, "Logger disabled", nil)
 	default:
 		_, _ = m.ReplyText(c, "Invalid argument. Use 'enable', 'disable', 'on', or 'off'.", nil)

--- a/src/handlers/extras.go
+++ b/src/handlers/extras.go
@@ -10,7 +10,9 @@ package handlers
 
 import (
 	"ashokshau/tgmusic/config"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +25,35 @@ func Args(m *gotdbot.Message) string {
 		return ""
 	}
 	return strings.TrimSpace(strings.Join(Messages[1:], " "))
+}
+
+func firstName(c *gotdbot.Client, m *gotdbot.Message) string {
+	if m.SenderId == nil {
+		return "Unknown"
+	}
+
+	if u, ok := m.SenderId.(*gotdbot.MessageSenderUser); ok {
+		user, err := c.GetUser(u.UserId)
+		if err != nil {
+			return "Unknown"
+		}
+		return user.FirstName
+	}
+
+	if ch, ok := m.SenderId.(*gotdbot.MessageSenderChat); ok {
+		chat, err := c.GetChat(ch.ChatId)
+		if err != nil {
+			return "Unknown"
+		}
+		return chat.Title
+	}
+
+	return "Unknown"
+}
+
+var replyOpts = &gotdbot.SendTextMessageOpts{
+	ParseMode:             "HTML",
+	DisableWebPagePreview: true,
 }
 
 // isDev checks if the user is a developer.
@@ -48,6 +79,75 @@ func SenderID(sender gotdbot.MessageSender) int64 {
 	default:
 		return 0
 	}
+}
+
+// getTargetUserID resolves a target user ID from a reply or command arguments.
+// Resolution order: replied message → numeric ID → @username lookup.
+func getTargetUserID(c *gotdbot.Client, m *gotdbot.Message) (int64, error) {
+	if m.ReplyToMessageID() != 0 {
+		return resolveFromReply(c, m)
+	}
+
+	args := strings.Fields(Args(m))
+	if len(args) == 0 {
+		return 0, errors.New("no target specified: reply to a message or provide a user ID/username")
+	}
+
+	userID, err := resolveFromArg(c, args[0])
+	if err != nil {
+		return 0, err
+	}
+
+	if m.SenderID() == userID {
+		return 0, errors.New("cannot perform action on yourself")
+	}
+
+	return userID, nil
+}
+
+// resolveFromReply extracts the sender ID from the replied-to message.
+func resolveFromReply(c *gotdbot.Client, m *gotdbot.Message) (int64, error) {
+	replyMsg, err := m.GetRepliedMessage(c)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch replied message: %w", err)
+	}
+
+	userID := replyMsg.SenderID()
+	if userID == 0 {
+		return 0, errors.New("replied message has no identifiable sender")
+	}
+
+	return userID, nil
+}
+
+// resolveFromArg parses a user ID or @username from a raw argument string.
+func resolveFromArg(c *gotdbot.Client, arg string) (int64, error) {
+	if id, err := strconv.ParseInt(arg, 10, 64); err == nil {
+		if id <= 0 {
+			return 0, fmt.Errorf("invalid user ID: %d", id)
+		}
+		return id, nil
+	}
+
+	return resolveUsername(c, arg)
+}
+
+// resolveUsername looks up a Telegram username and returns its chat ID.
+func resolveUsername(c *gotdbot.Client, username string) (int64, error) {
+	username = strings.TrimPrefix(username, "@")
+	if username == "" {
+		return 0, errors.New("username cannot be empty")
+	}
+
+	chat, err := c.SearchPublicChat(username)
+	if err != nil {
+		return 0, fmt.Errorf("username lookup failed for %q: %w", username, err)
+	}
+	if chat == nil {
+		return 0, fmt.Errorf("no user found for username %q", username)
+	}
+
+	return chat.Id, nil
 }
 
 // plural returns the unit with correct singular/plural form.

--- a/src/handlers/filters.go
+++ b/src/handlers/filters.go
@@ -19,16 +19,14 @@ import (
 	td "github.com/AshokShau/gotdbot"
 )
 
-// checkBotAdmin verifies the bot is an admin with CanInviteUsers permission.
-// Returns true if the bot is owner/admin with required rights, false otherwise.
 func checkBotAdmin(c *td.Client, chatID int64, replyErr func(msg string)) bool {
 	botStatus, err := cache.GetUserAdmin(c, chatID, c.Me.Id, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "is not an admin in chat") {
-			replyErr("❌ Bot is not an admin in this chat.\nPlease promote me with Invite Users permission.")
+			replyErr("Bot is not an administrator in this chat. Please promote the bot with invite users permission.")
 		} else {
 			c.Logger.Warn("GetUserAdmin error", "error", err)
-			replyErr("⚠️ Failed to get bot admin status.")
+			replyErr("Unable to verify bot administrator status.")
 		}
 		return false
 	}
@@ -38,17 +36,16 @@ func checkBotAdmin(c *td.Client, chatID int64, replyErr func(msg string)) bool {
 		return true
 	case *td.ChatMemberStatusAdministrator:
 		if s.Rights == nil || !s.Rights.CanInviteUsers {
-			replyErr("⚠️ Bot doesn't have permission to invite users.")
+			replyErr("The bot does not have permission to invite users.")
 			return false
 		}
 		return true
 	default:
-		replyErr("❌ Bot is not an admin in this chat.\nUse /reload to refresh admin cache.")
+		replyErr("Bot is not an administrator in this chat. Use /reload to refresh admin cache.")
 		return false
 	}
 }
 
-// adminMode checks if the bot is an admin in the chat and enforces admin mode restrictions.
 func adminMode(c *td.Client, ctx *td.Context) bool {
 	m := ctx.EffectiveMessage
 	if m.IsPrivate() {
@@ -56,55 +53,50 @@ func adminMode(c *td.Client, ctx *td.Context) bool {
 	}
 
 	chatID := m.ChatId
-	dbCtx, cancel := db.Ctx()
-	defer cancel()
 
 	if !checkBotAdmin(c, chatID, func(msg string) { _, _ = m.ReplyText(c, msg, nil) }) {
 		return false
 	}
 
 	userID := m.SenderID()
-	switch db.Instance.GetAdminMode(dbCtx, chatID) {
+	switch db.Instance.GetAdminMode(chatID) {
 	case utils.Everyone:
 		return true
 	case utils.Admins:
-		if db.Instance.IsAdmin(dbCtx, chatID, userID) || db.Instance.IsAuthUser(dbCtx, chatID, userID) {
+		if db.Instance.IsAdmin(chatID, userID) || db.Instance.IsAuthUser(chatID, userID) {
 			return true
 		}
-		_, _ = m.ReplyText(c, "❌ You are not an admin in this chat.", nil)
+		_, _ = m.ReplyText(c, "You must be an administrator to use this command.", nil)
 		return false
 	default:
-		_, _ = m.ReplyText(c, "❌ You are not an authorized user in this chat.", nil)
+		_, _ = m.ReplyText(c, "You are not authorized to use this command.", nil)
 		return false
 	}
 }
 
 func adminModeCB(c *td.Client, cb *td.UpdateNewCallbackQuery) bool {
 	chatID := cb.ChatId
-	dbCtx, cancel := db.Ctx()
-	defer cancel()
 
-	if !checkBotAdmin(c, chatID, func(msg string) { _ = cb.Answer(c, 300, true, msg, "") }) {
+	if !checkBotAdmin(c, chatID, func(msg string) { _ = cb.Answer(c, 0, true, msg, "") }) {
 		return false
 	}
 
 	userID := cb.SenderUserId
-	switch db.Instance.GetAdminMode(dbCtx, chatID) {
+	switch db.Instance.GetAdminMode(chatID) {
 	case utils.Everyone:
 		return true
 	case utils.Admins:
-		if db.Instance.IsAdmin(dbCtx, chatID, userID) || db.Instance.IsAuthUser(dbCtx, chatID, userID) {
+		if db.Instance.IsAdmin(chatID, userID) || db.Instance.IsAuthUser(chatID, userID) {
 			return true
 		}
-		_ = cb.Answer(c, 300, true, "❌ You are not an admin in this chat.", "")
+		_ = cb.Answer(c, 0, true, "You must be an administrator to use this action.", "")
 		return false
 	default:
-		_ = cb.Answer(c, 300, true, "❌ You are not an authorized user in this chat.", "")
+		_ = cb.Answer(c, 0, true, "You are not authorized to use this action.", "")
 		return false
 	}
 }
 
-// playMode checks if the bot is an admin and enforces play mode restrictions.
 func playMode(c *td.Client, ctx *td.Context) bool {
 	m := ctx.EffectiveMessage
 	if m.IsPrivate() {
@@ -112,15 +104,12 @@ func playMode(c *td.Client, ctx *td.Context) bool {
 	}
 
 	chatID := m.ChatID()
-	dbCtx, cancel := db.Ctx()
-	defer cancel()
 
 	if !checkBotAdmin(c, chatID, func(msg string) { _, _ = m.ReplyText(c, msg, nil) }) {
 		return false
 	}
 
-	// only admins + auth users can play if play mode is enabled
-	if db.Instance.GetPlayMode(dbCtx, chatID) {
+	if db.Instance.GetPlayMode(chatID) {
 		admins, err := cache.GetAdmins(c, chatID, false)
 		if err != nil {
 			c.Logger.Warn("getAdmins error", "error", err)
@@ -132,8 +121,8 @@ func playMode(c *td.Client, ctx *td.Context) bool {
 			return SenderID(a.MemberId) == senderID
 		})
 
-		if !isAdmin && !db.Instance.IsAuthUser(dbCtx, chatID, senderID) {
-			_, _ = m.ReplyText(c, "🚫 Play mode is enabled. Only admins and authorized users can play.", nil)
+		if !isAdmin && !db.Instance.IsAuthUser(chatID, senderID) {
+			_, _ = m.ReplyText(c, "Play mode is enabled. Only administrators and authorized users can start playback.", nil)
 			return false
 		}
 	}

--- a/src/handlers/help.go
+++ b/src/handlers/help.go
@@ -28,62 +28,62 @@ func getHelpCategories() map[string]struct {
 		Markup  *td.ReplyMarkupInlineKeyboard
 	}{
 		"help_user": {
-			Title:   "🎧 User Commands",
-			Content: "<b>Playback:</b>\n• <code>/play [song]</code> — Play music\n\n<b>Utilities:</b>\n• <code>/start</code> — Start bot\n• <code>/privacy</code> — Privacy Policy\n• <code>/queue</code> — View queue",
+			Title:   "User Commands",
+			Content: "<b>Playback:</b>\n• <code>/play [song]</code> — Play a track\n\n<b>Utilities:</b>\n• <code>/start</code> — Start the bot\n• <code>/privacy</code> — View privacy policy\n• <code>/queue</code> — Show current queue",
 			Markup:  core.BackHelpMenuKeyboard(),
 		},
 		"help_admin": {
-			Title:   "⚙️ Admin Commands",
-			Content: "<b>Controls:</b>\n• <code>/skip</code> — Skip track\n• <code>/pause</code> — Pause\n• <code>/resume</code> — Resume\n• <code>/seek [sec]</code> — Seek\n\n<b>Queue:</b>\n• <code>/remove [x]</code> — Remove track\n• <code>/loop [0-10]</code> — Loop queue\n\n<b>Access:</b>\n• <code>/auth [reply]</code> — Authorize user\n• <code>/unauth [reply]</code> — Unauthorize\n• <code>/authlist</code> — List authorized",
+			Title:   "Admin Commands",
+			Content: "<b>Controls:</b>\n• <code>/skip</code> — Skip the current track\n• <code>/pause</code> — Pause playback\n• <code>/resume</code> — Resume playback\n• <code>/seek [sec]</code> — Seek to position\n\n<b>Queue:</b>\n• <code>/remove [x]</code> — Remove a track\n• <code>/loop [0-10]</code> — Set loop count\n\n<b>Access:</b>\n• <code>/auth [reply]</code> — Authorize user\n• <code>/unauth [reply]</code> — Remove authorization\n• <code>/authlist</code> — List authorized users",
 			Markup:  core.BackHelpMenuKeyboard(),
 		},
 		"help_devs": {
-			Title:   "🛠 Developer Tools",
-			Content: "<b>System:</b>\n• <code>/stats</code> — Usage stats\n\n<b>Maintenance:</b>\n• <code>/av</code> — Active voice chats",
+			Title:   "Developer Commands",
+			Content: "<b>System:</b>\n• <code>/stats</code> — Show usage statistics\n\n<b>Maintenance:</b>\n• <code>/av</code> — Active voice chats",
 			Markup:  core.BackHelpMenuKeyboard(),
 		},
 		"help_owner": {
-			Title:   "🔐 Owner Commands",
+			Title:   "Owner Commands",
 			Content: "<b>Settings:</b>\n• <code>/settings</code> — Chat settings",
 			Markup:  core.BackHelpMenuKeyboard(),
 		},
 		"help_playlist": {
-			Title:   "🎵 Playlist Commands",
-			Content: "<b>Playlist Management:</b>\n• <code>/createplaylist [name]</code> — Create playlist\n• <code>/deleteplaylist [id]</code> — Delete playlist\n• <code>/addtoplaylist [id] [url]</code> — Add song\n• <code>/removefromplaylist [id] [url]</code> — Remove song\n• <code>/playlistinfo [id]</code> — Playlist info\n• <code>/myplaylists</code> — My playlists",
+			Title:   "Playlist Commands",
+			Content: "<b>Management:</b>\n• <code>/createplaylist [name]</code> — Create a playlist\n• <code>/deleteplaylist [id]</code> — Delete a playlist\n• <code>/addtoplaylist [id] [url]</code> — Add a track\n• <code>/removefromplaylist [id] [url]</code> — Remove a track\n• <code>/playlistinfo [id]</code> — Show playlist info\n• <code>/myplaylists</code> — List your playlists",
 			Markup:  core.BackHelpMenuKeyboard(),
 		},
 	}
 }
 
-// helpCallbackHandler handles callbacks from the help keyboard.
-// It returns an error if any.
 func helpCallbackHandler(c *td.Client, ctx *td.Context) error {
 	cb := ctx.Update.UpdateNewCallbackQuery
 	data := cb.DataString()
+
 	user, err := c.GetUser(cb.SenderUserId)
 	if err != nil {
 		user = &td.User{FirstName: "User", Id: cb.SenderUserId}
 	}
 
 	helpCategories := getHelpCategories()
+
 	if strings.Contains(data, "help_all") {
-		_ = cb.Answer(c, 0, false, "📖 Displaying all help categories...", "")
-		response := fmt.Sprintf("Hello %s!\n\nI am %s, a fast and powerful music player for Telegram.\n\n<b>Supported Platforms:</b> YouTube, Spotify, Apple Music, SoundCloud.\n\nClick the <b>Help</b> button below for more information.", user.FirstName, c.Me.FirstName)
-		_, _ = cb.EditMessageText(c, response, &td.EditTextMessageOpts{ReplyMarkup: core.HelpMenuKeyboard(), ParseMode: "HTML"})
+		_ = cb.Answer(c, 0, false, "Opening help menu...", "")
+		response := fmt.Sprintf("Hello %s,\n\nI am %s, a fast and powerful music player for Telegram.\n\n<b>Supported platforms:</b> YouTube, Spotify, Apple Music, SoundCloud.\n\nUse the buttons below to explore available commands.", user.FirstName, c.Me.FirstName)
+		_, _ = cb.EditMessageText(c, response, &td.EditTextMessageOpts{ReplyMarkup: core.HelpMenuKeyboard(), ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 	}
 
 	if strings.Contains(data, "help_back") {
-		_ = cb.Answer(c, 0, false, "🏠 Returning to home...", "")
-		response := fmt.Sprintf("Hello %s!\n\nI am %s, a fast and powerful music player for Telegram.\n\n<b>Supported Platforms:</b> YouTube, Spotify, Apple Music, SoundCloud.\n\nClick the <b>Help</b> button below for more information.", user.FirstName, c.Me.FirstName)
-		_, _ = cb.EditMessageText(c, response, &td.EditTextMessageOpts{ReplyMarkup: core.AddMeMarkup(c.Me.Usernames.EditableUsername), ParseMode: "HTML"})
+		_ = cb.Answer(c, 0, false, "Returning to main menu...", "")
+		response := fmt.Sprintf("Hello %s,\n\nI am %s, a fast and powerful music player for Telegram.\n\n<b>Supported platforms:</b> YouTube, Spotify, Apple Music, SoundCloud.\n\nUse the buttons below to explore available commands.", user.FirstName, c.Me.FirstName)
+		_, _ = cb.EditMessageText(c, response, &td.EditTextMessageOpts{ReplyMarkup: core.AddMeMarkup(c.Me.Usernames.EditableUsername), ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 	}
 
 	if category, ok := helpCategories[data]; ok {
 		_ = cb.Answer(c, 0, false, category.Title, "")
-		text := fmt.Sprintf("<b>%s</b>\n\n%s\n\n🔙 <i>Use buttons below to go back.</i>", category.Title, category.Content)
-		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: category.Markup, ParseMode: "HTML"})
+		text := fmt.Sprintf("<b>%s</b>\n\n%s\n\n<i>Use the buttons below to go back.</i>", category.Title, category.Content)
+		_, _ = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: category.Markup, ParseMode: "HTML", DisableWebPagePreview: true})
 		return nil
 	}
 

--- a/src/handlers/helpers.go
+++ b/src/handlers/helpers.go
@@ -98,8 +98,6 @@ func getFile(m *td.Message) (*td.File, string) {
 }
 
 // coalesce returns the first non-empty string.
-// It takes two strings as input.
-// It returns the first non-empty string.
 func coalesce(a, b string) string {
 	if a != "" {
 		return a
@@ -108,8 +106,6 @@ func coalesce(a, b string) string {
 }
 
 // truncate truncates a string to a maximum length.
-// It takes a string and a maximum length as input.
-// It returns the truncated string.
 func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s

--- a/src/handlers/loop.go
+++ b/src/handlers/loop.go
@@ -17,7 +17,6 @@ import (
 	td "github.com/AshokShau/gotdbot"
 )
 
-// loopHandler handles the /loop command.
 func loopHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
@@ -27,40 +26,36 @@ func loopHandler(c *td.Client, ctx *td.Context) error {
 	chatID := m.ChatId
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, err := m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, err := m.ReplyText(c, "There is no active playback in the video chat.", nil)
 		return err
 	}
 
 	args := Args(m)
 	if args == "" {
-		_, err := m.ReplyText(c, "<b>🔁 Loop Control</b>\n\n<b>Usage:</b> <code>/loop [count]</code>\n• <code>0</code> to disable loop\n• <code>1-10</code> to set the loop count", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, err := m.ReplyText(c, "<b>Loop Control</b>\n\n<b>Usage:</b> <code>/loop [count]</code>\n0 to disable looping\n1-10 to set the number of repeats", &td.SendTextMessageOpts{ParseMode: "HTML"})
 		return err
 	}
 
 	argsInt, err := strconv.Atoi(args)
 	if err != nil {
-		_, _ = m.ReplyText(c, "❌ Invalid loop count provided. Please use a number between 0 and 10.", nil)
+		_, _ = m.ReplyText(c, "Invalid loop value. Please provide a number between 0 and 10.", nil)
 		return nil
 	}
 
 	if argsInt < 0 || argsInt > 10 {
-		_, err = m.ReplyText(c, "⚠️ The loop count must be between 0 and 10.", nil)
+		_, err = m.ReplyText(c, "Loop count must be between 0 and 10.", nil)
 		return err
 	}
 
 	cache.ChatCache.SetLoopCount(chatID, argsInt)
+
 	var action string
 	if argsInt == 0 {
 		action = "Looping has been disabled"
 	} else {
-		action = fmt.Sprintf("The loop has been set to %d time(s)", argsInt)
+		action = fmt.Sprintf("Looping has been set to %d time(s)", argsInt)
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown"}
-	}
-
-	_, err = m.ReplyText(c, fmt.Sprintf("🔁 %s.\n\n└ Changed by: %s", action, user.FirstName), nil)
+	_, err = m.ReplyText(c, fmt.Sprintf("%s.\nChanged by: %s", action, firstName(c, m)), nil)
 	return err
 }

--- a/src/handlers/mute.go
+++ b/src/handlers/mute.go
@@ -18,7 +18,6 @@ import (
 	td "github.com/AshokShau/gotdbot"
 )
 
-// muteHandler handles the /mute command.
 func muteHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
@@ -31,25 +30,19 @@ func muteHandler(c *td.Client, ctx *td.Context) error {
 
 	chatID := m.ChatId
 	if !cache.ChatCache.IsActive(chatID) {
-		_, err := m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, err := m.ReplyText(c, "There is no active playback in the video chat.", nil)
 		return err
 	}
 
 	if _, err := vc.Calls.Mute(chatID); err != nil {
-		_, err = m.ReplyText(c, fmt.Sprintf("❌ An error occurred while muting the playback: %s", err.Error()), nil)
+		_, err = m.ReplyText(c, fmt.Sprintf("Failed to mute the playback: %s", err.Error()), nil)
 		return err
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown"}
-	}
-
-	_, err = m.ReplyText(c, fmt.Sprintf("🔇 Playback has been muted by %s.", user.FirstName), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("mute")})
+	_, err := m.ReplyText(c, fmt.Sprintf("Playback has been muted by %s.", firstName(c, m)), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("mute")})
 	return err
 }
 
-// unmuteHandler handles the /unmute command.
 func unmuteHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
@@ -62,20 +55,15 @@ func unmuteHandler(c *td.Client, ctx *td.Context) error {
 
 	chatID := m.ChatId
 	if !cache.ChatCache.IsActive(chatID) {
-		_, err := m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, err := m.ReplyText(c, "There is no active playback in the video chat.", nil)
 		return err
 	}
 
 	if _, err := vc.Calls.Unmute(chatID); err != nil {
-		_, _ = m.ReplyText(c, fmt.Sprintf("❌ An error occurred while unmuting the playback: %s", err.Error()), nil)
+		_, err = m.ReplyText(c, fmt.Sprintf("Failed to unmute the playback: %s", err.Error()), nil)
 		return err
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown"}
-	}
-
-	_, err = m.ReplyText(c, fmt.Sprintf("🔊 Playback has been unmuted by %s.", user.FirstName), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("unmute")})
+	_, err := m.ReplyText(c, fmt.Sprintf("Playback has been unmuted by %s.", firstName(c, m)), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("unmute")})
 	return err
 }

--- a/src/handlers/participant.go
+++ b/src/handlers/participant.go
@@ -110,12 +110,9 @@ func handleParticipant(client *gotdbot.Client, ctx *gotdbot.Context) error {
 
 func storeChatReference(chatID int64) {
 
-	ctx, cancel := db.Ctx()
-	defer cancel()
-
 	slog.Debug("Storing chat reference for chat", "chat_id", chatID)
 
-	if err := db.Instance.AddChat(ctx, chatID); err != nil {
+	if err := db.Instance.AddChat(chatID); err != nil {
 		slog.Error("Failed to add chat  to database", "chat_id", chatID, "error", err)
 	}
 }
@@ -313,7 +310,6 @@ func handlePromotionDemotion(
 }
 
 func updateStatusCache(chatID, userID int64, status gotdbot.ChatMemberStatus) {
-
 	call, _, err := vc.Calls.GetGroupAssistant(chatID)
 	if err != nil {
 		return

--- a/src/handlers/pause.go
+++ b/src/handlers/pause.go
@@ -18,34 +18,28 @@ import (
 	td "github.com/AshokShau/gotdbot"
 )
 
-// pauseHandler handles the /pause command.
 func pauseHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
 	}
+
 	m := ctx.EffectiveMessage
 	chatID := m.ChatId
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, _ = m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, _ = m.ReplyText(c, "There is no active playback in the video chat.", nil)
 		return nil
 	}
 
 	if _, err := vc.Calls.Pause(chatID); err != nil {
-		_, _ = m.ReplyText(c, fmt.Sprintf("❌ An error occurred while pausing the playback: %s", err.Error()), nil)
+		_, _ = m.ReplyText(c, fmt.Sprintf("Failed to pause the playback: %s", err.Error()), nil)
 		return nil
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown"}
-	}
-
-	_, err = m.ReplyText(c, fmt.Sprintf("⏸️ Playback has been paused by %s.", user.FirstName), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("pause")})
+	_, err := m.ReplyText(c, fmt.Sprintf("Playback has been paused by %s.", firstName(c, m)), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("pause")})
 	return err
 }
 
-// resumeHandler handles the /resume command.
 func resumeHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
@@ -59,20 +53,15 @@ func resumeHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, _ = m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, _ = m.ReplyText(c, "There is no active playback in the video chat.", nil)
 		return nil
 	}
 
 	if _, err := vc.Calls.Resume(chatID); err != nil {
-		_, _ = m.ReplyText(c, fmt.Sprintf("❌ An error occurred while resuming the playback: %s", err.Error()), nil)
+		_, _ = m.ReplyText(c, fmt.Sprintf("Failed to resume the playback: %s", err.Error()), nil)
 		return nil
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown", LastName: ""}
-	}
-
-	_, err = m.ReplyText(c, fmt.Sprintf("▶️ Playback has been resumed by %s.", user.FirstName), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("resume")})
+	_, err := m.ReplyText(c, fmt.Sprintf("Playback has been resumed by %s.", firstName(c, m)), &td.SendTextMessageOpts{ReplyMarkup: core.ControlButtons("resume")})
 	return err
 }

--- a/src/handlers/play.go
+++ b/src/handlers/play.go
@@ -9,18 +9,15 @@
 package handlers
 
 import (
-	"context"
-	"fmt"
-	"html"
-	"strings"
-	"time"
-
 	"ashokshau/tgmusic/config"
 	"ashokshau/tgmusic/src/core"
 	"ashokshau/tgmusic/src/core/cache"
 	"ashokshau/tgmusic/src/core/db"
 	"ashokshau/tgmusic/src/core/dl"
 	"ashokshau/tgmusic/src/vc"
+	"fmt"
+	"html"
+	"strings"
 
 	"ashokshau/tgmusic/src/utils"
 
@@ -49,22 +46,27 @@ func handlePlay(c *td.Client, ctx *td.Context, isVideo bool) error {
 	m := ctx.EffectiveMessage
 
 	if queueLen := cache.ChatCache.GetQueueLength(chatID); queueLen > 10 {
-		_, _ = m.ReplyText(c, "⚠️ Queue is full (max 10 tracks). Use /end to clear.", nil)
+		_, _ = m.ReplyText(c, "Queue is full (max 10 tracks). Use /end to clear.", nil)
 		return td.EndGroups
 	}
 
 	isReply := m.ReplyToMessageID() != 0
-	url := getUrl(c, m, isReply)
 	args := Args(m)
+	url := getUrl(c, m, isReply)
+
 	rMsg := m
 	var err error
+	if isReply && args == "" && url == "" {
+		r, err := m.GetRepliedMessage(c)
+		if err == nil && r != nil {
+			args = r.Text()
+		}
+	}
 
 	input := coalesce(url, args)
 
 	if strings.HasPrefix(input, "tgpl_") {
-		ctx, cancel := db.Ctx()
-		defer cancel()
-		playlist, err := db.Instance.GetPlaylist(ctx, input)
+		playlist, err := db.Instance.GetPlaylist(input)
 		if err != nil {
 			_, err = m.ReplyText(c, "❌ Playlist not found.", nil)
 			return err
@@ -89,13 +91,13 @@ func handlePlay(c *td.Client, ctx *td.Context, isVideo bool) error {
 		rMsg, err = utils.GetMessage(c, input)
 		if err != nil {
 			c.Logger.Warn("failed to parse message", "error", err.Error())
-			_, err = m.ReplyText(c, "❌ Invalid Telegram link.", nil)
+			_, err = m.ReplyText(c, "Invalid Telegram link.", nil)
 			return err
 		}
 	} else if isReply {
 		rMsg, err = m.GetRepliedMessage(c)
 		if err != nil {
-			_, err = m.ReplyText(c, "❌ Invalid reply message.", nil)
+			_, err = m.ReplyText(c, "Invalid reply message.", nil)
 			return err
 		}
 	}
@@ -105,7 +107,7 @@ func handlePlay(c *td.Client, ctx *td.Context, isVideo bool) error {
 	}
 
 	if url == "" && args == "" && (!isReply || !isValidMedia(rMsg)) {
-		_, _ = m.ReplyText(c, "🎵 <b>Usage:</b>\n/play [song or URL]\n\n<b>Supported Platforms:</b>\n- YouTube\n- Spotify\n- JioSaavn\n- Apple Music", &td.SendTextMessageOpts{ReplyMarkup: core.SupportKeyboard(), ParseMode: "HTML"})
+		_, _ = m.ReplyText(c, "<b>Usage:</b>\n/play [song or URL]\n\n<b>Supported Platforms:</b>\n- YouTube\n- Spotify\n- JioSaavn\n- Apple Music", &td.SendTextMessageOpts{ReplyMarkup: core.SupportKeyboard(), ParseMode: "HTML"})
 		return td.EndGroups
 	}
 
@@ -122,41 +124,37 @@ func handlePlay(c *td.Client, ctx *td.Context, isVideo bool) error {
 	wrapper := dl.NewDownloaderWrapper(input)
 	if url != "" {
 		if !wrapper.IsValid() {
-			_, _ = updater.EditText(c, "❌ Invalid URL or unsupported platform.\n\n<b>Supported Platforms:</b>\n- YouTube\n- Spotify\n- JioSaavn\n- Apple Music", &td.EditTextMessageOpts{ReplyMarkup: core.SupportKeyboard(), ParseMode: "HTML"})
+			_, _ = updater.EditText(c, "Invalid URL or unsupported platform.\n\n<b>Supported Platforms:</b>\n- YouTube\n- Spotify\n- JioSaavn\n- Apple Music", &td.EditTextMessageOpts{ReplyMarkup: core.SupportKeyboard(), ParseMode: "HTML"})
 			return td.EndGroups
 		}
 
-		ctx2, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		defer cancel()
-		trackInfo, err := wrapper.GetInfo(ctx2)
+		trackInfo, err := wrapper.GetInfo()
 		if err != nil {
 			_, _ = updater.EditText(c, fmt.Sprintf("❌ Error fetching track info: %s", err.Error()), nil)
 			return td.EndGroups
 		}
 
 		if trackInfo.Results == nil || len(trackInfo.Results) == 0 {
-			_, _ = updater.EditText(c, "❌ No tracks found.", nil)
+			_, _ = updater.EditText(c, "No tracks found.", nil)
 			return td.EndGroups
 		}
 
 		return handleUrl(c, m, updater, trackInfo, chatID, isVideo)
 	}
 
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel2()
-	return handleTextSearch(c, m, updater, wrapper, chatID, isVideo, ctx2)
+	return handleTextSearch(c, m, updater, wrapper, chatID, isVideo)
 }
 
 // handleMedia handles playing media from a message.
 func handleMedia(c *td.Client, m *td.Message, updater *td.Message, dlMsg *td.Message, chatId int64, isVideo bool) error {
 	file, fileName := getFile(dlMsg)
 	if file == nil {
-		_, err := updater.EditText(c, "❌ No valid media found in the message.", nil)
+		_, err := updater.EditText(c, "No valid media found in the message.", nil)
 		return err
 	}
 
 	if file.Size > config.Conf.MaxFileSize {
-		_, err := updater.EditText(c, fmt.Sprintf("❌ File too large. Max size: %d MB.", config.Conf.MaxFileSize/(1024*1024)), nil)
+		_, err := updater.EditText(c, fmt.Sprintf("File too large. Max size: %d MB.", config.Conf.MaxFileSize/(1024*1024)), nil)
 		if err != nil {
 			c.Logger.Warn("Edit message failed", "error", err)
 		}
@@ -165,7 +163,7 @@ func handleMedia(c *td.Client, m *td.Message, updater *td.Message, dlMsg *td.Mes
 
 	fileId := dlMsg.RemoteFileID()
 	if _track := cache.ChatCache.GetTrackIfExists(chatId, fileId); _track != nil {
-		_, err := updater.EditText(c, "✅ Track already in queue or playing.", nil)
+		_, err := updater.EditText(c, "Track already in queue or playing.", nil)
 		return err
 	}
 
@@ -176,14 +174,8 @@ func handleMedia(c *td.Client, m *td.Message, updater *td.Message, dlMsg *td.Mes
 		link.Link = ""
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		c.Logger.Warn("Failed to get user info", "error", err)
-		user = &td.User{FirstName: "Unknown"}
-	}
-
 	saveCache := utils.CachedTrack{
-		URL: link.Link, Name: fileName, User: user.FirstName, TrackID: fileId,
+		URL: link.Link, Name: fileName, User: firstName(c, m), TrackID: fileId,
 		Duration: dur, IsVideo: isVideo, Platform: utils.Telegram,
 	}
 
@@ -191,7 +183,7 @@ func handleMedia(c *td.Client, m *td.Message, updater *td.Message, dlMsg *td.Mes
 
 	if qLen > 1 {
 		queueInfo := fmt.Sprintf(
-			"<b>🎧 Added to Queue (#%d)</b>\n\n<b>Track:</b> <a href='%s'>%s</a>\n<b>Duration:</b> %s\n<b>By:</b> %s",
+			"<u><b>Added to queue: %d</b></u>\n\n<b>Title:</b> <a href='%s'>%s</a>\n\n<b>Duration:</b> %s min\n<b>Requested by:</b> %s",
 			qLen, saveCache.URL, saveCache.Name, utils.SecToMin(saveCache.Duration), saveCache.User,
 		)
 		_, err := updater.EditText(c, queueInfo, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("play"), ParseMode: "HTML", DisableWebPagePreview: true})
@@ -220,7 +212,7 @@ func handleMedia(c *td.Client, m *td.Message, updater *td.Message, dlMsg *td.Mes
 	}
 
 	nowPlaying := fmt.Sprintf(
-		"🎵 <b>Now Playing:</b>\n\n<b>Track:</b> <a href='%s'>%s</a>\n<b>Duration:</b> %s\n<b>By:</b> %s",
+		"<u><b>| Started streaming</b></u>\n\n<b>Title:</b> <a href='%s'>%s</a>\n\n<b>Duration:</b> %s min\n<b>Requested by:</b> %s",
 		saveCache.URL, saveCache.Name, utils.SecToMin(saveCache.Duration), saveCache.User,
 	)
 
@@ -234,8 +226,8 @@ func handleMedia(c *td.Client, m *td.Message, updater *td.Message, dlMsg *td.Mes
 }
 
 // handleTextSearch handles a text search for a song.
-func handleTextSearch(c *td.Client, m *td.Message, updater *td.Message, wrapper *dl.DownloaderWrapper, chatId int64, isVideo bool, ctx context.Context) error {
-	searchResult, err := wrapper.Search(ctx)
+func handleTextSearch(c *td.Client, m *td.Message, updater *td.Message, wrapper *dl.DownloaderWrapper, chatId int64, isVideo bool) error {
+	searchResult, err := wrapper.Search()
 	if err != nil {
 		_, err = updater.EditText(c, fmt.Sprintf("❌ Search failed: %s", err.Error()), nil)
 		return err
@@ -248,7 +240,7 @@ func handleTextSearch(c *td.Client, m *td.Message, updater *td.Message, wrapper 
 
 	song := searchResult.Results[0]
 	if _track := cache.ChatCache.GetTrackIfExists(chatId, song.Id); _track != nil {
-		_, err := updater.EditText(c, "✅ Track already in queue or playing.", nil)
+		_, err := updater.EditText(c, "Track already in queue or playing.", nil)
 		return err
 	}
 
@@ -260,7 +252,7 @@ func handleUrl(c *td.Client, m *td.Message, updater *td.Message, trackInfo utils
 	if len(trackInfo.Results) == 1 {
 		track := trackInfo.Results[0]
 		if _track := cache.ChatCache.GetTrackIfExists(chatId, track.Id); _track != nil {
-			_, err := updater.EditText(c, "✅ Track already in queue or playing.", nil)
+			_, err := updater.EditText(c, "Track already in queue or playing.", nil)
 			return err
 		}
 		return handleSingleTrack(c, m, updater, track, "", chatId, isVideo)
@@ -276,14 +268,8 @@ func handleSingleTrack(c *td.Client, m *td.Message, updater *td.Message, song ut
 		return err
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		c.Logger.Warn("Failed to get user info", "error", err)
-		user = &td.User{FirstName: "Unknown"}
-	}
-
 	saveCache := utils.CachedTrack{
-		URL: song.Url, Name: song.Title, User: user.FirstName, FilePath: filePath,
+		URL: song.Url, Name: song.Title, User: firstName(c, m), FilePath: filePath,
 		Thumbnail: song.Thumbnail, TrackID: song.Id, Duration: song.Duration, Channel: song.Channel, Views: song.Views,
 		IsVideo: isVideo, Platform: song.Platform,
 	}
@@ -292,40 +278,37 @@ func handleSingleTrack(c *td.Client, m *td.Message, updater *td.Message, song ut
 
 	if qLen > 1 {
 		queueInfo := fmt.Sprintf(
-			"<b>🎧 Added to Queue (#%d)</b>\n\n<b>Track:</b> <a href='%s'>%s</a>\n<b>Duration:</b> %s\n<b>By:</b> %s",
+			"<u><b>Added to queue: %d</b></u>\n\n<b>Title:</b> <a href='%s'>%s</a>\n\n<b>Duration:</b> %s min\n<b>Requested by:</b> %s",
 			qLen, saveCache.URL, saveCache.Name, utils.SecToMin(saveCache.Duration), saveCache.User,
 		)
 
-		_, err = updater.EditText(c, queueInfo, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("play"), ParseMode: "HTML", DisableWebPagePreview: true})
+		_, err := updater.EditText(c, queueInfo, &td.EditTextMessageOpts{ReplyMarkup: core.ControlButtons("play"), ParseMode: "HTML", DisableWebPagePreview: true})
 		return err
 	}
 
 	if saveCache.FilePath == "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-
-		dlResult, err := dl.DownloadSong(ctx, &saveCache, c)
+		dlResult, err := dl.DownloadCachedTrack(&saveCache, c)
 		if err != nil {
 			cache.ChatCache.RemoveCurrentSong(chatId)
-			_, err = updater.EditText(c, fmt.Sprintf("❌ Download failed: %s", err.Error()), nil)
+			_, err = updater.EditText(c, fmt.Sprintf("Download failed: %s", err.Error()), nil)
 			return err
 		}
 
 		saveCache.FilePath = dlResult
 	}
 
-	if err = vc.Calls.PlayMedia(chatId, saveCache.FilePath, saveCache.IsVideo, ""); err != nil {
+	if err := vc.Calls.PlayMedia(chatId, saveCache.FilePath, saveCache.IsVideo, ""); err != nil {
 		cache.ChatCache.RemoveCurrentSong(chatId)
 		_, err = updater.EditText(c, err.Error(), &td.EditTextMessageOpts{ParseMode: "HTML", DisableWebPagePreview: true})
 		return err
 	}
 
 	nowPlaying := fmt.Sprintf(
-		"🎵 <b>Now Playing:</b>\n\n<b>Track:</b> <a href='%s'>%s</a>\n<b>Duration:</b> %s\n<b>By:</b> %s",
+		"<u><b>| Started streaming</b></u>\n\n<b>Title:</b> <a href='%s'>%s</a>\n\n<b>Duration:</b> %s min\n<b>Requested by:</b> %s",
 		saveCache.URL, saveCache.Name, utils.SecToMin(song.Duration), saveCache.User,
 	)
 
-	_, err = updater.EditText(c, nowPlaying, &td.EditTextMessageOpts{
+	_, err := updater.EditText(c, nowPlaying, &td.EditTextMessageOpts{
 		ReplyMarkup:           core.ControlButtons("play"),
 		ParseMode:             "HTML",
 		DisableWebPagePreview: true,
@@ -342,17 +325,11 @@ func handleSingleTrack(c *td.Client, m *td.Message, updater *td.Message, song ut
 // handleMultipleTracks handles multiple tracks.
 func handleMultipleTracks(c *td.Client, m *td.Message, updater *td.Message, tracks []utils.MusicTrack, chatId int64, isVideo bool) error {
 	if len(tracks) == 0 {
-		_, err := updater.EditText(c, "❌ No tracks found.", nil)
+		_, err := updater.EditText(c, "No tracks found.", nil)
 		return err
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		c.Logger.Warn("Failed to get user info", "error", err)
-		user = &td.User{FirstName: "Unknown"}
-	}
-
-	queueHeader := "<b>📥 Added to Queue:</b>\n<blockquote expandable>\n"
+	queueHeader := "<u><b>Added to Queue:</b></u>\n<blockquote expandable>\n"
 	var tracksToAdd []*utils.CachedTrack
 	var skippedTracks []string
 
@@ -367,7 +344,7 @@ func handleMultipleTracks(c *td.Client, m *td.Message, updater *td.Message, trac
 
 		saveCache := &utils.CachedTrack{
 			Name: track.Title, TrackID: track.Id, Duration: track.Duration,
-			Thumbnail: track.Thumbnail, User: user.FirstName, Platform: track.Platform,
+			Thumbnail: track.Thumbnail, User: firstName(c, m), Platform: track.Platform,
 			IsVideo: isVideo, URL: track.Url, Channel: track.Channel, Views: track.Views,
 		}
 		tracksToAdd = append(tracksToAdd, saveCache)
@@ -375,10 +352,10 @@ func handleMultipleTracks(c *td.Client, m *td.Message, updater *td.Message, trac
 
 	if len(tracksToAdd) == 0 {
 		if len(skippedTracks) > 0 {
-			_, err = updater.EditText(c, fmt.Sprintf("❌ All tracks were skipped (max duration %d min).", config.Conf.SongDurationLimit/60), nil)
+			_, err := updater.EditText(c, fmt.Sprintf("All tracks were skipped (max duration %d min).", config.Conf.SongDurationLimit/60), nil)
 			return err
 		}
-		_, err = updater.EditText(c, "❌ No valid tracks found.", nil)
+		_, err := updater.EditText(c, "No valid tracks found.", nil)
 		return err
 	}
 
@@ -404,8 +381,8 @@ func handleMultipleTracks(c *td.Client, m *td.Message, updater *td.Message, trac
 
 	sb.WriteString("</blockquote>")
 	queueSummary := fmt.Sprintf(
-		"\n<b>📋 Queue Total:</b> %d\n<b>⏱ Duration:</b> %s\n<b>👤 By:</b> %s",
-		qLenAfter, utils.SecToMin(totalDuration), user.FirstName,
+		"\n<b>Queue Total:</b> %d\n<b>Duration:</b> %s min\n<b>Requested by:</b> %s",
+		qLenAfter, utils.SecToMin(totalDuration), firstName(c, m),
 	)
 
 	sb.WriteString(queueSummary)
@@ -423,7 +400,7 @@ func handleMultipleTracks(c *td.Client, m *td.Message, updater *td.Message, trac
 		_ = vc.Calls.PlayNext(chatId)
 	}
 
-	_, err = updater.EditText(c, fullMessage, &td.EditTextMessageOpts{
+	_, err := updater.EditText(c, fullMessage, &td.EditTextMessageOpts{
 		ParseMode:             "HTML",
 		ReplyMarkup:           core.ControlButtons("play"),
 		DisableWebPagePreview: true,

--- a/src/handlers/playlist.go
+++ b/src/handlers/playlist.go
@@ -22,23 +22,21 @@ import (
 func createPlaylistHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 	userID := m.SenderID()
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
 	args := Args(m)
 	if args == "" {
-		_, err := m.ReplyText(c, "<b>Usage:</b> /createplaylist [playlist name]", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, err := m.ReplyText(c, "<b>Usage:</b> /createplaylist [playlist name]", replyOpts)
 		return err
 	}
 
-	userPlaylists, err := db.Instance.GetUserPlaylists(ctx2, userID)
+	userPlaylists, err := db.Instance.GetUserPlaylists(userID)
 	if err != nil {
-		_, err := m.ReplyText(c, "Error creating playlist.", nil)
+		_, err = m.ReplyText(c, "Unable to fetch your playlists. Please try again later.", nil)
 		return err
 	}
 
 	if len(userPlaylists) >= 10 {
-		_, _ = m.ReplyText(c, fmt.Sprintf("You have reached the limit of %d playlists.", 10), nil)
+		_, _ = m.ReplyText(c, "You have reached the maximum limit of 10 playlists.", nil)
 		return td.EndGroups
 	}
 
@@ -46,81 +44,138 @@ func createPlaylistHandler(c *td.Client, ctx *td.Context) error {
 		args = string([]rune(args)[:40])
 	}
 
-	playlistID, err := db.Instance.CreatePlaylist(ctx2, args, userID)
+	playlistID, err := db.Instance.CreatePlaylist(args, userID)
 	if err != nil {
-		_, err := m.ReplyText(c, fmt.Sprintf("Error creating playlist: %s", err.Error()), nil)
+		_, err = m.ReplyText(c, fmt.Sprintf("Failed to create playlist: %s", err.Error()), nil)
 		return err
 	}
 
-	_, err = m.ReplyText(c, fmt.Sprintf("✅ Playlist '%s' created (ID: <code>%s</code>).", args, playlistID), &td.SendTextMessageOpts{ParseMode: "HTML"})
+	_, err = m.ReplyText(
+		c,
+		fmt.Sprintf(
+			"Playlist <b>%s</b> has been created successfully.\nID: <code>%s</code>",
+			args,
+			playlistID,
+		),
+		replyOpts,
+	)
+
 	return td.EndGroups
 }
 
 func deletePlaylistHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 	userID := m.SenderID()
-	ctx2, cancel := db.Ctx()
-	defer cancel()
+
 	args := Args(m)
 	if args == "" {
-		_, err := m.ReplyText(c, "<b>Usage:</b> /deleteplaylist [playlist id]", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, err := m.ReplyText(
+			c,
+			"<b>Usage:</b> /deleteplaylist [playlist id]",
+			&td.SendTextMessageOpts{ParseMode: "HTML"},
+		)
 		return err
 	}
-	playlist, err := db.Instance.GetPlaylist(ctx2, args)
+
+	playlist, err := db.Instance.GetPlaylist(args)
 	if err != nil {
-		_, err := m.ReplyText(c, "❌ Playlist not found.", nil)
+		_, err := m.ReplyText(
+			c,
+			"The specified playlist could not be found. Please check the playlist ID.",
+			nil,
+		)
 		return err
 	}
+
 	if playlist.UserID != userID {
-		_, err := m.ReplyText(c, "❌ You don't own this playlist.", nil)
+		_, err := m.ReplyText(
+			c,
+			"You can only delete playlists that you created.",
+			nil,
+		)
 		return err
 	}
 
-	err = db.Instance.DeletePlaylist(ctx2, args, userID)
+	err = db.Instance.DeletePlaylist(args, userID)
 	if err != nil {
-		_, err := m.ReplyText(c, fmt.Sprintf("Error deleting playlist: %s", err.Error()), nil)
+		_, err := m.ReplyText(
+			c,
+			fmt.Sprintf("Failed to delete the playlist: %s", err.Error()),
+			nil,
+		)
 		return err
 	}
 
-	_, err = m.ReplyText(c, fmt.Sprintf("✅ Playlist '%s' deleted.", playlist.Name), nil)
+	_, err = m.ReplyText(
+		c,
+		fmt.Sprintf("Playlist <b>%s</b> has been deleted successfully.", playlist.Name),
+		&td.SendTextMessageOpts{ParseMode: "HTML"},
+	)
+
 	return err
 }
-
 func addToPlaylistHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 	userID := m.SenderID()
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
 	args := strings.SplitN(Args(m), " ", 2)
 	if len(args) != 2 {
-		_, err := m.ReplyText(c, "<b>Usage:</b> /addtoplaylist [playlist id] [song url]", &td.SendTextMessageOpts{ParseMode: "HTML"})
-		return err
-	}
-	playlistID := args[0]
-	songURL := args[1]
-	playlist, err := db.Instance.GetPlaylist(ctx2, playlistID)
-	if err != nil {
-		_, err := m.ReplyText(c, "❌ Playlist not found.", nil)
-		return err
-	}
-	if playlist.UserID != userID {
-		_, err := m.ReplyText(c, "❌ You don't own this playlist.", nil)
-		return err
-	}
-	wrapper := dl.NewDownloaderWrapper(songURL)
-	if !wrapper.IsValid() {
-		_, err := m.ReplyText(c, "❌ Invalid URL or unsupported platform.", nil)
-		return err
-	}
-	trackInfo, err := wrapper.GetInfo(ctx2)
-	if err != nil {
-		_, err := m.ReplyText(c, fmt.Sprintf("❌ Error fetching track info: %s", err.Error()), nil)
+		_, err := m.ReplyText(
+			c,
+			"<b>Usage:</b> /addtoplaylist [playlist id] [song url]",
+			&td.SendTextMessageOpts{ParseMode: "HTML"},
+		)
 		return err
 	}
 
-	if trackInfo.Results == nil {
-		_, err := m.ReplyText(c, "❌ No tracks found.", nil)
+	playlistID := args[0]
+	songURL := args[1]
+
+	playlist, err := db.Instance.GetPlaylist(playlistID)
+	if err != nil {
+		_, err := m.ReplyText(
+			c,
+			"The specified playlist could not be found. Please verify the playlist ID.",
+			nil,
+		)
+		return err
+	}
+
+	if playlist.UserID != userID {
+		_, err := m.ReplyText(
+			c,
+			"You can only modify playlists that you created.",
+			nil,
+		)
+		return err
+	}
+
+	wrapper := dl.NewDownloaderWrapper(songURL)
+	if !wrapper.IsValid() {
+		_, err := m.ReplyText(
+			c,
+			"The provided URL is invalid or the platform is not supported.",
+			nil,
+		)
+		return err
+	}
+
+	trackInfo, err := wrapper.GetInfo()
+	if err != nil {
+		_, err := m.ReplyText(
+			c,
+			fmt.Sprintf("Unable to retrieve track information: %s", err.Error()),
+			nil,
+		)
+		return err
+	}
+
+	if trackInfo.Results == nil || len(trackInfo.Results) == 0 {
+		_, err := m.ReplyText(
+			c,
+			"No playable tracks were found for the provided link.",
+			nil,
+		)
 		return err
 	}
 
@@ -132,46 +187,65 @@ func addToPlaylistHandler(c *td.Client, ctx *td.Context) error {
 		Platform: trackInfo.Results[0].Platform,
 	}
 
-	err = db.Instance.AddSongToPlaylist(ctx2, playlistID, song)
+	err = db.Instance.AddSongToPlaylist(playlistID, song)
 	if err != nil {
-		_, err := m.ReplyText(c, fmt.Sprintf("Error adding song: %s", err.Error()), nil)
+		_, err := m.ReplyText(
+			c,
+			fmt.Sprintf("Failed to add the track to the playlist: %s", err.Error()),
+			nil,
+		)
 		return err
 	}
-	_, err = m.ReplyText(c, fmt.Sprintf("✅ '%s' added to playlist '%s'.", song.Name, playlist.Name), nil)
+
+	_, err = m.ReplyText(
+		c,
+		fmt.Sprintf(
+			"Track <b>%s</b> has been added to playlist <b>%s</b>.",
+			song.Name,
+			playlist.Name,
+		),
+		replyOpts,
+	)
+
 	return err
 }
 
 func removeFromPlaylistHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 	userID := m.SenderID()
-	ctx2, cancel := db.Ctx()
-	defer cancel()
+
 	args := strings.SplitN(Args(m), " ", 2)
 	if len(args) != 2 {
-		_, err := m.ReplyText(c, "<b>Usage:</b> /removefromplaylist [playlist id] [song number or url]", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, err := m.ReplyText(
+			c,
+			"<b>Usage:</b> /removefromplaylist [playlist id] [song number or url]",
+			&td.SendTextMessageOpts{ParseMode: "HTML"},
+		)
 		return err
 	}
+
 	playlistID := args[0]
 	songIdentifier := args[1]
-	playlist, err := db.Instance.GetPlaylist(ctx2, playlistID)
+
+	playlist, err := db.Instance.GetPlaylist(playlistID)
 	if err != nil {
-		_, err = m.ReplyText(c, "❌ Playlist not found.", nil)
+		_, err = m.ReplyText(c, "Playlist not found.", nil)
 		return err
 	}
 
 	if playlist.UserID != userID {
-		_, err = m.ReplyText(c, "❌ You don't own this playlist.", nil)
+		_, err = m.ReplyText(c, "You do not own this playlist.", nil)
 		return err
 	}
 
 	songIndex, err := strconv.Atoi(songIdentifier)
 	var trackID string
+
 	if err == nil {
 		if songIndex < 1 || songIndex > len(playlist.Songs) {
-			_, err := m.ReplyText(c, "❌ Invalid song number.", nil)
+			_, err := m.ReplyText(c, "Invalid song number.", nil)
 			return err
 		}
-
 		trackID = playlist.Songs[songIndex-1].TrackID
 	} else {
 		for _, song := range playlist.Songs {
@@ -183,34 +257,36 @@ func removeFromPlaylistHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	if trackID == "" {
-		_, err = m.ReplyText(c, "❌ Song not found in playlist.", nil)
+		_, err = m.ReplyText(c, "Song not found in playlist.", nil)
 		return err
 	}
 
-	c.Logger.Info("Removing song from playlist", "id", playlistID, "id", trackID)
-	err = db.Instance.RemoveSongFromPlaylist(ctx2, playlistID, trackID)
+	err = db.Instance.RemoveSongFromPlaylist(playlistID, trackID)
 	if err != nil {
 		_, err = m.ReplyText(c, fmt.Sprintf("Error removing song: %s", err.Error()), nil)
 		return err
 	}
 
-	_, err = m.ReplyText(c, fmt.Sprintf("✅ Song removed from playlist '%s'.", playlist.Name), nil)
+	_, err = m.ReplyText(c, fmt.Sprintf("Song removed from playlist '%s'.", playlist.Name), nil)
 	return err
 }
 
 func playlistInfoHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
-	ctx2, cancel := db.Ctx()
-	defer cancel()
+
 	args := Args(m)
 	if args == "" {
-		_, err := m.ReplyText(c, "<b>Usage:</b> /playlistinfo [playlist id]", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, err := m.ReplyText(
+			c,
+			"<b>Usage:</b> /playlistinfo [playlist id]",
+			&td.SendTextMessageOpts{ParseMode: "HTML"},
+		)
 		return err
 	}
 
-	playlist, err := db.Instance.GetPlaylist(ctx2, args)
+	playlist, err := db.Instance.GetPlaylist(args)
 	if err != nil {
-		_, err = m.ReplyText(c, "❌ Playlist not found.", nil)
+		_, err = m.ReplyText(c, "Playlist not found.", nil)
 		return err
 	}
 
@@ -221,33 +297,51 @@ func playlistInfoHandler(c *td.Client, ctx *td.Context) error {
 
 	owner, err := c.GetUser(playlist.UserID)
 	if err != nil {
-		c.Logger.Warn(err.Error())
 		return td.EndGroups
 	}
 
-	_, err = m.ReplyText(c, fmt.Sprintf("<b>Playlist Info</b>\n\n<b>Name:</b> %s\n<b>Owner:</b> %s\n<b>Songs:</b> %d\n\n%s", playlist.Name, owner.FirstName, len(playlist.Songs), strings.Join(songs, "\n")), &td.SendTextMessageOpts{ParseMode: "HTML"})
+	_, err = m.ReplyText(
+		c,
+		fmt.Sprintf(
+			"<b>Playlist Info</b>\n\n<b>Name:</b> %s\n<b>Owner:</b> %s\n<b>Songs:</b> %d\n\n%s",
+			playlist.Name,
+			owner.FirstName,
+			len(playlist.Songs),
+			strings.Join(songs, "\n"),
+		),
+		&td.SendTextMessageOpts{ParseMode: "HTML"},
+	)
 	return td.EndGroups
 }
 
 func myPlaylistsHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
-
 	userID := m.SenderID()
-	ctx2, cancel := db.Ctx()
-	defer cancel()
-	playlists, err := db.Instance.GetUserPlaylists(ctx2, userID)
+
+	playlists, err := db.Instance.GetUserPlaylists(userID)
 	if err != nil {
 		_, err := m.ReplyText(c, fmt.Sprintf("Error fetching playlists: %s", err.Error()), nil)
 		return err
 	}
+
 	if len(playlists) == 0 {
-		_, err := m.ReplyText(c, "❌ You don't have any playlists.", nil)
+		_, err := m.ReplyText(c, "You do not have any playlists.", nil)
 		return err
 	}
+
 	var playlistInfo []string
 	for _, playlist := range playlists {
-		playlistInfo = append(playlistInfo, fmt.Sprintf("- %s (<code>%s</code>)", playlist.Name, playlist.ID))
+		playlistInfo = append(
+			playlistInfo,
+			fmt.Sprintf("- %s (<code>%s</code>)", playlist.Name, playlist.ID),
+		)
 	}
-	_, err = m.ReplyText(c, fmt.Sprintf("<b>My Playlists</b>\n\n%s", strings.Join(playlistInfo, "\n")), &td.SendTextMessageOpts{ParseMode: "HTML"})
+
+	_, err = m.ReplyText(
+		c,
+		fmt.Sprintf("<b>My Playlists</b>\n\n%s", strings.Join(playlistInfo, "\n")),
+		&td.SendTextMessageOpts{ParseMode: "HTML"},
+	)
+
 	return err
 }

--- a/src/handlers/queue.go
+++ b/src/handlers/queue.go
@@ -26,6 +26,7 @@ func queueHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
 	}
+
 	m := ctx.EffectiveMessage
 	chatID := ctx.EffectiveChatId
 
@@ -37,12 +38,12 @@ func queueHandler(c *td.Client, ctx *td.Context) error {
 
 	queue := cache.ChatCache.GetQueue(chatID)
 	if len(queue) == 0 {
-		_, _ = m.ReplyText(c, "📭 Queue is empty.", nil)
+		_, _ = m.ReplyText(c, "The queue is empty.", nil)
 		return nil
 	}
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, _ = m.ReplyText(c, "⏸ Nothing is playing.", nil)
+		_, _ = m.ReplyText(c, "The bot is not streaming in the video chat.", nil)
 		return nil
 	}
 
@@ -99,10 +100,17 @@ func queueHandler(c *td.Client, ctx *td.Context) error {
 		if playedTime > 0 && playedTime < math.MaxInt {
 			progress = utils.SecToMin(int(playedTime))
 		}
-		sb.WriteString(fmt.Sprintf("<b>Queue for %s</b>\n\n<b>Now Playing:</b>\n• <code>%s</code>\n• %s/%s min\n\n<b>Total:</b> %d tracks", chat.Title, truncate(current.Name, 45), progress, utils.SecToMin(current.Duration), len(queue)))
+		sb.WriteString(fmt.Sprintf(
+			"<b>Queue for %s</b>\n\n<b>Now Playing:</b>\n• <code>%s</code>\n• %s/%s min\n\n<b>Total:</b> %d tracks",
+			chat.Title,
+			truncate(current.Name, 45),
+			progress,
+			utils.SecToMin(current.Duration),
+			len(queue),
+		))
 		text = sb.String()
 	}
 
-	_, err = m.ReplyText(c, text, &td.SendTextMessageOpts{ParseMode: "HTML"})
+	_, err = m.ReplyText(c, text, replyOpts)
 	return err
 }

--- a/src/handlers/remove.go
+++ b/src/handlers/remove.go
@@ -27,39 +27,34 @@ func removeHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, _ = m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, _ = m.ReplyText(c, "The bot is not streaming in the video chat.", nil)
 		return nil
 	}
 
 	queue := cache.ChatCache.GetQueue(chatID)
 	if len(queue) == 0 {
-		_, _ = m.ReplyText(c, "📭 The queue is currently empty.", nil)
+		_, _ = m.ReplyText(c, "The queue is currently empty.", nil)
 		return nil
 	}
 
 	args := Args(m)
 	if args == "" {
-		_, _ = m.ReplyText(c, "<b>❌ Remove Track</b>\n\n<b>Usage:</b> <code>/remove [track number]</code>\n\n- Use <code>1</code> to remove the first track, <code>2</code> for the second, and so on.", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, _ = m.ReplyText(c, "<b>Usage:</b> <code>/remove [track number]</code>\n\nUse <code>1</code> to remove the first track, <code>2</code> for the second, and so on.", replyOpts)
 		return nil
 	}
 
 	trackNum, err := strconv.Atoi(args)
 	if err != nil {
-		_, _ = m.ReplyText(c, "⚠️ Please enter a valid track number.", nil)
+		_, _ = m.ReplyText(c, "Please provide a valid track number.", nil)
 		return nil
 	}
 
 	if trackNum <= 0 || trackNum > len(queue) {
-		_, _ = m.ReplyText(c, fmt.Sprintf("⚠️ The track number is not valid. Please choose a number between 1 and %d.", len(queue)), nil)
+		_, _ = m.ReplyText(c, fmt.Sprintf("Invalid track number. Please choose a number between 1 and %d.", len(queue)), nil)
 		return nil
 	}
 
 	cache.ChatCache.RemoveTrack(chatID, trackNum)
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown"}
-	}
-
-	_, err = m.ReplyText(c, fmt.Sprintf("✅ Track #%d has been removed by %s.", trackNum, user.FirstName), nil)
+	_, err = m.ReplyText(c, fmt.Sprintf("Track #%d has been removed by %s.", trackNum, firstName(c, m)), replyOpts)
 	return err
 }

--- a/src/handlers/seek.go
+++ b/src/handlers/seek.go
@@ -28,50 +28,56 @@ func seekHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, err := m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, err := m.ReplyText(c, "The bot is not streaming in the video chat.", nil)
 		return err
 	}
 
 	playingSong := cache.ChatCache.GetPlayingTrack(chatID)
 	if playingSong == nil {
-		_, err := m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, err := m.ReplyText(c, "The bot is not streaming in the video chat.", nil)
 		return err
 	}
 
 	args := Args(m)
 	if args == "" {
-		_, _ = m.ReplyText(c, "<b>❌ Seek Track</b>\n\n<b>Usage:</b> <code>/seek [seconds]</code>", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, _ = m.ReplyText(c, "<b>Usage:</b> /seek duration\n<b>Example:</b> <code>/seek 15</code>", replyOpts)
 		return nil
 	}
 
 	seekTime, err := strconv.Atoi(args)
 	if err != nil {
-		_, _ = m.ReplyText(c, "❌ Invalid seek time provided. Please use a valid number of seconds.", nil)
+		_, _ = m.ReplyText(c, "Invalid seek time provided. Please use a valid number of seconds.", nil)
 		return nil
 	}
 
-	if seekTime < 0 || seekTime < 20 {
-		_, _ = m.ReplyText(c, "⚠️ The minimum seek time is 20 seconds.", nil)
+	if seekTime < 10 {
+		_, _ = m.ReplyText(c, "Minimum seek time is 10 seconds.", nil)
 		return nil
 	}
 
 	currDur, err := vc.Calls.PlayedTime(chatID)
 	if err != nil {
-		_, _ = m.ReplyText(c, "❌ An error occurred while fetching the current track duration.", nil)
+		_, _ = m.ReplyText(c, "Failed to fetch the duration of the ongoing stream.", nil)
 		return nil
 	}
 
 	toSeek := int(currDur) + seekTime
 	if toSeek >= playingSong.Duration {
-		_, _ = m.ReplyText(c, fmt.Sprintf("⚠️ You cannot seek beyond the track's duration. The maximum seek time is %s.", utils.SecToMin(playingSong.Duration)), nil)
+		_, _ = m.ReplyText(c, fmt.Sprintf("You cannot seek beyond the track duration. Maximum allowed is %s.", utils.SecToMin(playingSong.Duration)), nil)
 		return nil
 	}
 
-	if err = vc.Calls.SeekStream(chatID, playingSong.FilePath, toSeek, playingSong.Duration, playingSong.IsVideo); err != nil {
-		_, _ = m.ReplyText(c, fmt.Sprintf("❌ An error occurred while seeking the track: %s", err.Error()), nil)
+	if err = vc.Calls.SeekStream(
+		chatID,
+		playingSong.FilePath,
+		toSeek,
+		playingSong.Duration,
+		playingSong.IsVideo,
+	); err != nil {
+		_, _ = m.ReplyText(c, fmt.Sprintf("An error occurred while seeking the track: %s", err.Error()), replyOpts)
 		return nil
 	}
 
-	_, _ = m.ReplyText(c, fmt.Sprintf("✅ The track has been seeked to %s.", utils.SecToMin(toSeek)), nil)
+	_, _ = m.ReplyText(c, fmt.Sprintf("<b>Stream skipped %s and started from %s seconds by</b> %s", utils.SecToMin(seekTime), utils.SecToMin(toSeek), firstName(c, m)), replyOpts)
 	return nil
 }

--- a/src/handlers/settings.go
+++ b/src/handlers/settings.go
@@ -26,8 +26,6 @@ func settingsHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	m := ctx.EffectiveMessage
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
 	chatID := ctx.EffectiveChatId
 	admins, err := cache.GetAdmins(c, chatID, false)
@@ -49,12 +47,14 @@ func settingsHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	// Get current settings
-	getPlayMode := db.Instance.GetPlayMode(ctx2, chatID)
+	getPlayMode := db.Instance.GetPlayMode(chatID)
 	playModeStr := utils.Everyone
 	if getPlayMode {
 		playModeStr = utils.Admins
 	}
-	getAdminMode := db.Instance.GetAdminMode(ctx2, chatID)
+	getAdminMode := db.Instance.GetAdminMode(chatID)
+	cmdDelete := db.Instance.GetCmdDelete(chatID)
+	language, _ := db.Instance.GetLanguage(chatID)
 
 	chat, err := m.GetChat(c)
 	if err != nil {
@@ -62,19 +62,16 @@ func settingsHandler(c *td.Client, ctx *td.Context) error {
 		return nil
 	}
 
-	text := fmt.Sprintf("<b>Settings for %s</b>\n\n<b>Play Mode:</b> %s\n<b>Admin Mode:</b> %s",
-		chat.Title, playModeStr, getAdminMode)
+	text := fmt.Sprintf("<u><b>%s settings</b></u>\n\nClick the buttons below to change this chat's current settings.",
+		chat.Title)
 
-	_, err = m.ReplyText(c, text, &td.SendTextMessageOpts{ReplyMarkup: core.SettingsKeyboard(playModeStr, getAdminMode), ParseMode: td.ParseModeHTML})
+	_, err = m.ReplyText(c, text, &td.SendTextMessageOpts{ReplyMarkup: core.SettingsKeyboard(playModeStr, getAdminMode, cmdDelete, language), ParseMode: td.ParseModeHTML})
 	return err
 }
 
 func settingsCallbackHandler(c *td.Client, ctx *td.Context) error {
 	chatID := ctx.EffectiveChatId
 	cb := ctx.Update.UpdateNewCallbackQuery
-
-	ctx2, cancel := db.Ctx()
-	defer cancel()
 
 	// Check admin permissions
 	admins, err := cache.GetAdmins(c, chatID, false)
@@ -92,64 +89,66 @@ func settingsCallbackHandler(c *td.Client, ctx *td.Context) error {
 	}
 
 	if !hasPerms {
-		err = cb.Answer(c, 300, true, "You don't have permission to change settings.", "")
+		err = cb.Answer(c, 0, true, "You don't have permission to change settings.", "")
 		return err
 	}
 
 	// Process the callback data
-	parts := strings.Split(cb.DataString(), "_")
-	if len(parts) < 3 {
+	data := cb.DataString()
+	if data == "settings_main" {
+		return cb.Answer(c, 0, false, "Update your chat settings", "")
+	}
+
+	parts := strings.Split(data, "_")
+	if len(parts) < 2 {
 		return nil
 	}
 
-	// Update the appropriate setting
 	settingType := parts[1]
-	settingValue := parts[2]
-
-	// Validate the setting value
-	validValues := map[string]bool{
-		utils.Admins:   true,
-		utils.Everyone: true,
-	}
-
-	if !validValues[settingValue] {
-		_ = cb.Answer(c, 300, true, "Update your chat settings", "")
-		return nil
-	}
 
 	switch settingType {
+	case "delete":
+		cmdDelete := db.Instance.GetCmdDelete(chatID)
+		_ = db.Instance.SetCmdDelete(chatID, !cmdDelete)
 	case "play":
-		adminPlay := settingValue == utils.Admins
-		_ = db.Instance.SetPlayMode(ctx2, chatID, adminPlay)
+		getPlayMode := db.Instance.GetPlayMode(chatID)
+		_ = db.Instance.SetPlayMode(chatID, !getPlayMode)
 	case "admin":
-		_ = db.Instance.SetAdminMode(ctx2, chatID, settingValue)
+		getAdminMode := db.Instance.GetAdminMode(chatID)
+		newMode := utils.Everyone
+		if getAdminMode == utils.Everyone {
+			newMode = utils.Admins
+		}
+		_ = db.Instance.SetAdminMode(chatID, newMode)
+	case "lang":
+		return cb.Answer(c, 0, true, "Language selection is not yet implemented via this menu.", "")
 	default:
-		_ = cb.Answer(c, 300, true, "Update your chat settings", "")
-		return nil
+		return cb.Answer(c, 0, true, "Unknown setting", "")
 	}
 
-	// Get updated settings
-	getPlayMode := db.Instance.GetPlayMode(ctx2, chatID)
+	getPlayMode := db.Instance.GetPlayMode(chatID)
 	playModeStr := utils.Everyone
 	if getPlayMode {
 		playModeStr = utils.Admins
 	}
-	getAdminMode := db.Instance.GetAdminMode(ctx2, chatID)
+	getAdminMode := db.Instance.GetAdminMode(chatID)
+	cmdDelete := db.Instance.GetCmdDelete(chatID)
+	language, _ := db.Instance.GetLanguage(chatID)
+
 	chat, err := c.GetChat(chatID)
 	if err != nil {
 		c.Logger.Warn("Failed to get chat", "error", err)
 		return nil
 	}
 
-	text := fmt.Sprintf("<b>Settings for %s</b>\n\n<b>Play Mode:</b> %s\n<b>Admin Mode:</b> %s",
-		chat.Title, playModeStr, getAdminMode)
+	text := fmt.Sprintf("<u><b>%s settings</b></u>\n\nClick the buttons below to change this chat's current settings.",
+		chat.Title)
 
-	_, err = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.SettingsKeyboard(playModeStr, getAdminMode), ParseMode: td.ParseModeHTML})
+	_, err = cb.EditMessageText(c, text, &td.EditTextMessageOpts{ReplyMarkup: core.SettingsKeyboard(playModeStr, getAdminMode, cmdDelete, language), ParseMode: td.ParseModeHTML})
 	if err != nil {
 		return err
 	}
 
-	_ = cb.Answer(c, 200, false, "Settings updated", "")
-	_, _ = cb.EditMessageText(c, text, nil)
+	_ = cb.Answer(c, 0, false, "Settings updated", "")
 	return nil
 }

--- a/src/handlers/skip.go
+++ b/src/handlers/skip.go
@@ -20,11 +20,12 @@ func skipHandler(c *td.Client, ctx *td.Context) error {
 	if !adminMode(c, ctx) {
 		return td.EndGroups
 	}
+
 	m := ctx.EffectiveMessage
 	chatID := ctx.EffectiveChatId
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, _ = m.ReplyText(c, "⏸ Nothing is playing.", nil)
+		_, _ = m.ReplyText(c, "The bot is not streaming in the video chat.", nil)
 		return nil
 	}
 

--- a/src/handlers/speed.go
+++ b/src/handlers/speed.go
@@ -27,36 +27,32 @@ func speedHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, err := m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, err := m.ReplyText(c, "The bot is not streaming in the video chat.", nil)
 		return err
 	}
 
 	if playingSong := cache.ChatCache.GetPlayingTrack(chatID); playingSong == nil {
-		_, err := m.ReplyText(c, "⏸ No track currently playing.", nil)
+		_, err := m.ReplyText(c, "The bot is not streaming in the video chat.", nil)
 		return err
 	}
 
 	args := Args(m)
 	if args == "" {
-		_, _ = m.ReplyText(c, "<b>❌ Change Speed</b>\n\n<b>Usage:</b> <code>/speed [value]</code>\n\n- The speed can be set from <code>0.5</code> to <code>4.0</code>.", &td.SendTextMessageOpts{ParseMode: "HTML"})
+		_, _ = m.ReplyText(c, "<b>Change Playback Speed</b>\n\n<b>Usage:</b> <code>/speed [value]</code>\n\nThe speed can be set between <code>0.5</code> and <code>4.0</code>.", replyOpts)
 		return nil
 	}
 
 	speed, err := strconv.ParseFloat(args, 64)
 	if err != nil {
-		_, _ = m.ReplyText(c, "❌ Invalid speed value provided. Please use a number between 0.5 and 4.0.", nil)
-		return nil
-	}
-
-	if speed < 0.5 || speed > 4.0 {
-		_, _ = m.ReplyText(c, "⚠️ The speed must be between 0.5 and 4.0.", nil)
+		_, _ = m.ReplyText(c, "Invalid speed value. Please provide a number between 0.5 and 4.0.", nil)
 		return nil
 	}
 
 	if err = vc.Calls.ChangeSpeed(chatID, speed); err != nil {
-		_, _ = m.ReplyText(c, fmt.Sprintf("❌ An error occurred while changing the speed: %s", err.Error()), nil)
+		_, _ = m.ReplyText(c, fmt.Sprintf("An error occurred while changing the speed: %s", err.Error()), replyOpts)
 		return nil
 	}
-	_, _ = m.ReplyText(c, fmt.Sprintf("✅ The playback speed has been changed to %.2fx.", speed), nil)
+
+	_, _ = m.ReplyText(c, fmt.Sprintf("Playback speed has been set to <code>%.2fx</code>.", speed), replyOpts)
 	return nil
 }

--- a/src/handlers/start.go
+++ b/src/handlers/start.go
@@ -24,9 +24,7 @@ func pingHandler(c *td.Client, ctx *td.Context) error {
 	m := ctx.EffectiveMessage
 	start := time.Now()
 
-	updateLag := time.Since(time.Unix(int64(m.Date), 0)).Milliseconds()
-
-	msg, err := m.ReplyText(c, "⏱️ Pinging...", nil)
+	msg, err := m.ReplyText(c, "Pinging… please wait…", nil)
 	if err != nil {
 		return err
 	}
@@ -36,11 +34,10 @@ func pingHandler(c *td.Client, ctx *td.Context) error {
 
 	response := fmt.Sprintf(
 		"<b>📊 System Performance Metrics</b>\n\n"+
-			"⏱️ <b>Bot Latency:</b> <code>%d ms</code>\n"+
-			"🕒 <b>Uptime:</b> <code>%s</code>\n"+
-			"📩 <b>Update Lag:</b> <code>%d ms</code>\n"+
-			"⚙️ <b>Go Routines:</b> <code>%d</code>\n",
-		latency, uptime, updateLag, runtime.NumGoroutine(),
+			"<b>Bot Latency:</b> <code>%d ms</code>\n"+
+			"<b>Uptime:</b> <code>%s</code>\n"+
+			"<b>Go Routines:</b> <code>%d</code>\n",
+		latency, uptime, runtime.NumGoroutine(),
 	)
 
 	_, err = msg.EditText(c, response, &td.EditTextMessageOpts{ParseMode: "HTML"})
@@ -54,25 +51,21 @@ func startHandler(c *td.Client, ctx *td.Context) error {
 
 	if m.IsPrivate() {
 		go func(chatID int64) {
-			ctx, cancel := db.Ctx()
-			defer cancel()
-			_ = db.Instance.AddUser(ctx, chatID)
+			_ = db.Instance.AddUser(chatID)
 		}(chatID)
 	} else {
 		go func(chatID int64) {
-			ctx, cancel := db.Ctx()
-			defer cancel()
-			_ = db.Instance.AddChat(ctx, chatID)
+			_ = db.Instance.AddChat(chatID)
 		}(chatID)
 	}
 
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown"}
-	}
+	response := fmt.Sprintf(
+		"Hey %s,\nThis is %s !\n\nA music player bot with some awesome and useful features.\n<b>Supported Platforms:</b> YouTube, Spotify, Apple Music, SoundCloud.\n\n<b><i>Click on the help button for more info.</i></b>",
+		firstName(c, m),
+		c.Me.FirstName,
+	)
 
-	response := fmt.Sprintf("Hello %s!\n\nI am %s, a fast and powerful music player for Telegram.\n\n<b>Supported Platforms:</b> YouTube, Spotify, Apple Music, SoundCloud.\n\nClick the <b>Help</b> button below for more information.", user.FirstName, c.Me.FirstName)
-	_, err = m.ReplyText(c, response, &td.SendTextMessageOpts{
+	_, err := m.ReplyText(c, response, &td.SendTextMessageOpts{
 		ParseMode:   "HTML",
 		ReplyMarkup: core.AddMeMarkup(c.Me.Usernames.EditableUsername),
 	})

--- a/src/handlers/stats.go
+++ b/src/handlers/stats.go
@@ -10,7 +10,6 @@ package handlers
 
 import (
 	"ashokshau/tgmusic/src/vc"
-	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -170,7 +169,6 @@ func gatherAppStats() *AppStats {
 
 	return stats
 }
-
 func statsHandler(c *td.Client, ctx *td.Context) error {
 	if !isDev(ctx) {
 		return td.EndGroups
@@ -182,84 +180,68 @@ func statsHandler(c *td.Client, ctx *td.Context) error {
 		chatID = 0
 	}
 
-	ctx2, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	sysMsg, err := msg.ReplyText(c, "Collecting system statistics...", nil)
 	if err != nil {
 		return err
 	}
 
 	stats := gatherAppStats()
-	chats, _ := db.Instance.GetAllChats(ctx2)
-	users, _ := db.Instance.GetAllUsers(ctx2)
+
+	chats, _ := db.Instance.GetAllChats()
+	users, _ := db.Instance.GetAllUsers()
 	ntgCpuUsage, _ := vc.Calls.CpuUsage(chatID)
 
-	var sb strings.Builder
+	memLine := fmt.Sprintf("• Ram usage: %s\n", stats.AppMemUsed)
+	if stats.MemLimit != "" {
+		memLine = fmt.Sprintf("• Ram usage: %s | %s\n", stats.AppMemUsed, stats.MemLimit)
+	}
 
-	sb.WriteString(fmt.Sprintf(
-		"<b>%s — Runtime Status</b>\n",
+	text := fmt.Sprintf(
+		"<b>%s — Runtime Status</b>\n"+
+			"────────────────────────────────────\n\n"+
+			"<b>System</b>\n"+
+			"• CPU usage: %s (%d cores)\n"+
+			"• Ram usage: %s | %s\n"+
+			"• Storage: %s | %s\n\n"+
+			"<b>Application</b>\n"+
+			"• Uptime: %s\n"+
+			"• Goroutines: %d\n"+
+			"• Go Version: %s\n"+
+			"• CPU usage: %s\n"+
+			"• NTG Calls CPU: %.2f%%\n"+
+			"%s"+
+			"• Heap: %s\n"+
+			"• GC Runs: %d (pause %s)\n\n"+
+			"<b>Database</b>\n"+
+			"• Chats: %d\n"+
+			"• Users: %d\n\n"+
+			"────────────────────────────────────",
+
 		c.Me.FirstName,
-	))
-	sb.WriteString(strings.Repeat("─", 36) + "\n\n")
 
-	sb.WriteString("<b>System</b>\n")
-	sb.WriteString(fmt.Sprintf(
-		"• CPU usage: %s (%d cores)\n",
 		stats.SystemCPU,
 		stats.CPUCores,
-	))
-	sb.WriteString(fmt.Sprintf(
-		"• Ram usage: %s | %s\n",
 		stats.SystemMemUsed,
 		stats.SystemMemTotal,
-	))
-	sb.WriteString(fmt.Sprintf(
-		"• Storage: %s | %s\n\n",
 		stats.DiskUsed,
 		stats.DiskTotal,
-	))
 
-	sb.WriteString("<b>Application</b>\n")
-	sb.WriteString(fmt.Sprintf(
-		"• Uptime: %s\n• Goroutines: %d\n• Go Version: %s\n",
 		stats.Uptime,
 		stats.Goroutines,
 		stats.GoVersion,
-	))
-	sb.WriteString(fmt.Sprintf(
-		"• CPU usage: %s\n• NTG Calls CPU: %.2f%%\n",
 		stats.AppCPU,
 		ntgCpuUsage,
-	))
-	if stats.MemLimit != "" {
-		sb.WriteString(fmt.Sprintf(
-			"• Ram usage: %s | %s\n",
-			stats.AppMemUsed,
-			stats.MemLimit,
-		))
-	} else {
-		sb.WriteString(fmt.Sprintf(
-			"• Ram usage: %s\n",
-			stats.AppMemUsed,
-		))
-	}
-	sb.WriteString(fmt.Sprintf(
-		"• Heap: %s\n• GC Runs: %d (pause %s)\n\n",
+
+		memLine,
+
 		stats.AppHeap,
 		stats.GCCount,
 		stats.GCPause,
-	))
 
-	sb.WriteString("<b>Database</b>\n")
-	sb.WriteString(fmt.Sprintf(
-		"• Chats: %d\n• Users: %d\n",
 		len(chats),
 		len(users),
-	))
+	)
 
-	sb.WriteString("\n" + strings.Repeat("─", 36))
-
-	_, _ = sysMsg.EditText(c, sb.String(), &td.EditTextMessageOpts{ParseMode: "HTML"})
+	_, _ = sysMsg.EditText(c, text, &td.EditTextMessageOpts{ParseMode: "HTML"})
 	return nil
 }

--- a/src/handlers/stop.go
+++ b/src/handlers/stop.go
@@ -26,20 +26,11 @@ func stopHandler(c *td.Client, ctx *td.Context) error {
 	chatID := ctx.EffectiveChatId
 
 	if !cache.ChatCache.IsActive(chatID) {
-		_, _ = m.ReplyText(c, "⏸ Nothing is playing.", nil)
+		_, _ = m.ReplyText(c, "The bot isn't streaming in the video chat.", nil)
 		return nil
 	}
 
-	if err := vc.Calls.Stop(chatID); err != nil {
-		_, _ = m.ReplyText(c, fmt.Sprintf("❌ Error stopping playback: %s", err.Error()), nil)
-		return err
-	}
-
-	user, err := c.GetUser(m.SenderID())
-	if err != nil {
-		user = &td.User{FirstName: "Unknown"}
-	}
-
-	_, _ = m.ReplyText(c, fmt.Sprintf("⏹️ Stopped by %s. Queue cleared.", user.FirstName), nil)
+	_ = vc.Calls.Stop(chatID)
+	_, _ = m.ReplyText(c, fmt.Sprintf("<b>Stream ended by</b> %s", firstName(c, m)), replyOpts)
 	return nil
 }

--- a/src/handlers/watcher.go
+++ b/src/handlers/watcher.go
@@ -22,7 +22,6 @@ func handleVoiceChatMessage(c *td.Client, ctx *td.Context) error {
 	m := update.Message
 	chatID := ctx.EffectiveChatId
 
-	// Chat is not a Supergroup
 	if m.IsGroup() {
 		text := fmt.Sprintf(
 			"This chat (%d) is not a supergroup yet.\n<b>⚠️ Please convert this chat to a supergroup and add me as admin.</b>\n\nIf you don't know how to convert, use this guide:\n🔗 https://te.legra.ph/How-to-Convert-a-Group-to-a-Supergroup-01-02\n\nIf you have any questions, join our support group:",

--- a/src/init.go
+++ b/src/init.go
@@ -12,13 +12,12 @@ import (
 	"ashokshau/tgmusic/config"
 	"ashokshau/tgmusic/src/core/db"
 	"ashokshau/tgmusic/src/vc"
-	"context"
 
 	"github.com/AshokShau/gotdbot"
 )
 
 func Init(client *gotdbot.Client) error {
-	if err := db.InitDatabase(context.Background()); err != nil {
+	if err := db.InitDatabase(); err != nil {
 		return err
 	}
 

--- a/src/utils/models.go
+++ b/src/utils/models.go
@@ -63,6 +63,7 @@ const (
 	Gaana      = "Gaana"
 	DirectLink = "direct_link"
 	Tidal      = "tidal"
+	MXPlayer   = "mxplayer"
 )
 
 const (

--- a/src/vc/calls.go
+++ b/src/vc/calls.go
@@ -22,35 +22,29 @@ import "C"
 
 import (
 	"ashokshau/tgmusic/config"
+	"ashokshau/tgmusic/src/core"
+	"ashokshau/tgmusic/src/core/cache"
+	"ashokshau/tgmusic/src/core/db"
+	"ashokshau/tgmusic/src/core/dl"
 	"ashokshau/tgmusic/src/utils"
 	"ashokshau/tgmusic/src/vc/ntgcalls"
-	"ashokshau/tgmusic/src/vc/sessions"
 	"ashokshau/tgmusic/src/vc/ubot"
-	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
 	"log/slog"
 	"math/big"
 	"os"
-	"regexp"
 	"strings"
-	"time"
-
-	"ashokshau/tgmusic/src/core"
-	"ashokshau/tgmusic/src/core/cache"
-	"ashokshau/tgmusic/src/core/db"
-	"ashokshau/tgmusic/src/core/dl"
 
 	td "github.com/AshokShau/gotdbot"
-	tg "github.com/amarnathcjd/gogram/telegram"
 )
 
 const DefaultStreamURL = "https://t.me/FallenSongs/1295"
 
 // getClientIndex selects an assistant client index (0-based) for a given chat.
-// It prioritizes existing assignments from the database if they are not excluded.
-func (c *TelegramCalls) getClientIndex(chatID int64, excludeIndices []int) (int, error) {
+// It prioritizes existing assignments from the database.
+func (c *TelegramCalls) getClientIndex(chatID int64) (int, error) {
 	c.mu.RLock()
 	totalClients := len(c.uBContext)
 	c.mu.RUnlock()
@@ -59,62 +53,32 @@ func (c *TelegramCalls) getClientIndex(chatID int64, excludeIndices []int) (int,
 		return -1, fmt.Errorf("no clients are available")
 	}
 
-	var availableIndices []int
-	for i := 0; i < totalClients; i++ {
-		excluded := false
-		for _, ex := range excludeIndices {
-			if i == ex {
-				excluded = true
-				break
-			}
-		}
-		if !excluded {
-			availableIndices = append(availableIndices, i)
-		}
-	}
-
-	if len(availableIndices) == 0 {
-		return -1, fmt.Errorf("all available assistants (%d) are excluded", totalClients)
-	}
-
-	ctx, cancel := db.Ctx()
-	defer cancel()
-
-	// Check if an assistant is already assigned for this chat.
-	assignedIndex, err := db.Instance.GetAssistant(ctx, chatID)
+	assignedIndex, err := db.Instance.GetAssistant(chatID)
 	if err != nil {
 		slog.Info("[TelegramCalls] DB.GetAssistant error", "error", err)
 		assignedIndex = -1
 	}
 
-	// If already assigned and not excluded, use it.
-	if assignedIndex >= 0 {
-		isAvailable := false
-		for _, idx := range availableIndices {
-			if idx == assignedIndex {
-				isAvailable = true
-				break
-			}
-		}
-		if isAvailable {
-			return assignedIndex, nil
-		}
-		slog.Info("[TelegramCalls] Assigned assistant is excluded, selecting new one", "chat_id", chatID, "old", assignedIndex)
+	if assignedIndex >= 0 && assignedIndex < totalClients {
+		return assignedIndex, nil
 	}
 
-	// Select a new one from available indices.
-	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(availableIndices))))
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(totalClients)))
 	if err != nil {
 		slog.Info("[TelegramCalls] Could not generate a random number", "error", err)
-		return availableIndices[0], nil
+		newClientIndex := 0
+		if assignedIndex == -1 && chatID != 0 {
+			if _, err := db.Instance.AssignAssistant(chatID, newClientIndex); err != nil {
+				logger.Info("[TelegramCalls] DB.AssignAssistant error", "error", err)
+			}
+		}
+		return newClientIndex, nil
 	}
-	newClientIndex := availableIndices[n.Int64()]
 
-	// If no assistant was assigned at all, try to assign it.
-	// But don't overwrite yet if one was already assigned (it might be temporarily excluded).
-	if assignedIndex == -1 && chatID != 0 {
-		if _, err := db.Instance.AssignAssistant(ctx, chatID, newClientIndex); err != nil {
-			slog.Info("[TelegramCalls] DB.AssignAssistant error", "error", err)
+	newClientIndex := int(n.Int64())
+	if chatID != 0 {
+		if _, err := db.Instance.AssignAssistant(chatID, newClientIndex); err != nil {
+			logger.Info("[TelegramCalls] DB.AssignAssistant error", "error", err)
 		}
 	}
 
@@ -122,8 +86,8 @@ func (c *TelegramCalls) getClientIndex(chatID int64, excludeIndices []int) (int,
 }
 
 // GetGroupAssistant retrieves the ubot.Context and its index for a given chat.
-func (c *TelegramCalls) GetGroupAssistant(chatID int64, excludeIndices ...int) (*ubot.Context, int, error) {
-	clientIndex, err := c.getClientIndex(chatID, excludeIndices)
+func (c *TelegramCalls) GetGroupAssistant(chatID int64) (*ubot.Context, int, error) {
+	clientIndex, err := c.getClientIndex(chatID)
 	if err != nil {
 		return nil, -1, err
 	}
@@ -138,100 +102,43 @@ func (c *TelegramCalls) GetGroupAssistant(chatID int64, excludeIndices ...int) (
 	return call, clientIndex, nil
 }
 
-// StartClient initializes a new userbot client and adds it to the pool of available assistants.
-// It authenticates with Telegram using the provided API ID, API hash, and session string.
-// The session type is determined by the configuration (pyrogram, telethon, or gogram).
-func (c *TelegramCalls) StartClient(apiID int32, apiHash, stringSession string) (*ubot.Context, error) {
-	c.mu.Lock()
-	clientIndex := len(c.uBContext)
-	c.mu.Unlock()
-
-	clientName := fmt.Sprintf("client%d", clientIndex)
-
-	var sess *tg.Session
-	var err error
-
-	clientConfig := tg.ClientConfig{
-		AppID:         apiID,
-		AppHash:       apiHash,
-		MemorySession: true,
-		SessionName:   clientName,
-		FloodHandler:  handleFlood,
-		LogLevel:      tg.InfoLevel,
-	}
-
-	switch config.Conf.SessionType {
-	case "telethon":
-		sess, err = sessions.DecodeTelethonSessionString(stringSession)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode telethon session string for %s: %w", clientName, err)
-		}
-		clientConfig.StringSession = sess.Encode()
-	case "pyrogram":
-		sess, err = sessions.DecodePyrogramSessionString(stringSession)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode pyrogram session string for %s: %w", clientName, err)
-		}
-		clientConfig.StringSession = sess.Encode()
-	case "gogram":
-		clientConfig.StringSession = stringSession
-	default:
-		return nil, fmt.Errorf("unsupported session type: %s", config.Conf.SessionType)
-	}
-
-	mtProto, err := tg.NewClient(clientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the MTProto client: %w", err)
-	}
-
-	if err := mtProto.Start(); err != nil {
-		return nil, fmt.Errorf("failed to start the client: %w", err)
-	}
-
-	if mtProto.Me().Bot {
-		_ = mtProto.Stop()
-		return nil, fmt.Errorf("the client %s is a bot", clientName)
-	}
-
-	call, err := ubot.NewInstance(mtProto)
-	if err != nil {
-		_ = mtProto.Stop()
-		return nil, fmt.Errorf("failed to create the ubot instance: %w", err)
-	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.uBContext[clientIndex] = call
-	c.clients[clientIndex] = mtProto
-
-	mtProto.Logger.Info("[TelegramCalls] client %s has started successfully.", clientName)
-	return call, nil
-}
-
-// StopAllClients gracefully stops all active userbot clients and their associated voice calls.
-func (c *TelegramCalls) StopAllClients() {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	for _, call := range c.uBContext {
-		call.Close()
-	}
-
-	for idx, client := range c.clients {
-		slog.Info("[TelegramCalls] Stopping the client", "index", idx)
-		_ = client.Stop()
-	}
-}
-
-// PlayMedia plays media in a voice chat using ffmpeg. It downloads the file if necessary
-// and updates the cache and logger status.
+// PlayMedia plays media in a voice chat.
 func (c *TelegramCalls) PlayMedia(chatID int64, filePath string, video bool, ffmpegParameters string) error {
+	c.mu.RLock()
+	totalClients := len(c.uBContext)
+	c.mu.RUnlock()
+
+	if totalClients == 0 {
+		return fmt.Errorf("no clients are available")
+	}
+
+	var lastErr error
+	for i := 0; i < totalClients; i++ {
+		err := c.play(chatID, filePath, video, ffmpegParameters)
+		if err == nil {
+			return nil
+		}
+
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "FROZEN_METHOD_INVALID") ||
+			strings.Contains(errMsg, "CHANNELS_TOO_MUCH") ||
+			strings.Contains(errMsg, "FLOOD_WAIT_X") {
+			_ = db.Instance.RemoveAssistant(chatID)
+			lastErr = err
+			continue
+		}
+
+		return err
+	}
+
+	return lastErr
+}
+
+func (c *TelegramCalls) play(chatID int64, filePath string, video bool, ffmpegParameters string) error {
 	call, index, err := c.GetGroupAssistant(chatID)
 	if err != nil {
 		return err
 	}
-	ctx, cancel := db.Ctx()
-	defer cancel()
 
 	if chatID < 0 {
 		var joinErr error
@@ -244,16 +151,19 @@ func (c *TelegramCalls) PlayMedia(chatID int64, filePath string, video bool, ffm
 		_, _ = call.App.ResolvePeer(chatID)
 	}
 
-	slog.Debug("Playing media in chat", "id", chatID, "path", filePath, "index", index)
-
+	logger.Debug("Playing media in chat", "id", chatID, "path", filePath, "index", index)
 	mediaDesc := getMediaDescription(filePath, video, ffmpegParameters)
 	if err = call.Play(chatID, mediaDesc); err != nil {
-		logger.Error("Failed to play the media", "error", err, "index", index)
 		cache.ChatCache.ClearChat(chatID)
-		return fmt.Errorf("playback (client %d) failed: %w", index, err)
+		if strings.Contains(err.Error(), "is closed") {
+			return errors.New("<b>No active video chat found.</b>\n\nPlease start one and <b>try again</b>")
+		}
+
+		logger.Error("Failed to play the media", "error", err, "index", index)
+		return fmt.Errorf("client%d: playback failed: %w", index, err)
 	}
 
-	if db.Instance.GetLoggerStatus(ctx, c.bot.Me.Id) {
+	if db.Instance.GetLoggerStatus() {
 		go sendLogger(c.bot, chatID, cache.ChatCache.GetPlayingTrack(chatID))
 	}
 
@@ -267,10 +177,7 @@ func (c *TelegramCalls) downloadAndPrepareSong(song *utils.CachedTrack, reply *t
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancel()
-
-	dlPath, err := dl.DownloadSong(ctx, song, c.bot)
+	dlPath, err := dl.DownloadCachedTrack(song, c.bot)
 	if err != nil {
 		_, _ = reply.EditText(c.bot, "⚠️ Download failed. Skipping track...", nil)
 		return err
@@ -335,7 +242,7 @@ func (c *TelegramCalls) playSong(chatID int64, song *utils.CachedTrack) error {
 	}
 
 	text := fmt.Sprintf(
-		"<b>Now Playing:</b>\n\n<b>Track:</b> <a href='%s'>%s</a>\n<b>Duration:</b> %s\n<b>By:</b> %s",
+		"<u><b>| Started streaming</b></u>\n\n<b>Title:</b> <a href='%s'>%s</a>\n\n<b>Duration:</b> %s min\n<b>Requested by:</b> %s",
 		song.URL,
 		song.Name,
 		utils.SecToMin(song.Duration),
@@ -388,64 +295,67 @@ func (c *TelegramCalls) Pause(chatId int64) (bool, error) {
 }
 
 // Resume continues a paused media playback in a voice chat.
-// It returns true if the operation was successful, and an error otherwise.
 func (c *TelegramCalls) Resume(chatId int64) (bool, error) {
 	call, index, err := c.GetGroupAssistant(chatId)
 	if err != nil {
 		return false, err
 	}
+
 	res, err := call.Resume(chatId)
 	if err != nil {
-		slog.Warn("[Resume] Failed to resume the call", "error", err, "index", index)
-		return res, fmt.Errorf("failed to resume (client %d): %w", index, err)
+		logger.Warn("Failed to resume the call", "error", err, "index", index)
+		return res, fmt.Errorf("failed to resume: %w", err)
 	}
+
 	return res, err
 }
 
 // Mute silences the media playback in a voice chat.
-// It returns true if the operation was successful, and an error otherwise.
 func (c *TelegramCalls) Mute(chatId int64) (bool, error) {
 	call, index, err := c.GetGroupAssistant(chatId)
 	if err != nil {
 		return false, err
 	}
+
 	res, err := call.Mute(chatId)
 	if err != nil {
-		slog.Warn("[Mute] Failed to mute the call", "error", err, "index", index)
-		return res, fmt.Errorf("failed to mute (client %d): %w", index, err)
+		logger.Warn("Failed to mute the call", "error", err, "index", index)
+		return res, fmt.Errorf("failed to mute: %w", err)
 	}
+
 	return res, err
 }
 
 // Unmute restores the audio of a muted media playback in a voice chat.
-// It returns true if the operation was successful, and an error otherwise.
 func (c *TelegramCalls) Unmute(chatId int64) (bool, error) {
 	call, index, err := c.GetGroupAssistant(chatId)
 	if err != nil {
 		return false, err
 	}
+
 	res, err := call.Unmute(chatId)
 	if err != nil {
-		slog.Warn("[Unmute] Failed to unmute the call", "error", err, "index", index)
-		return res, fmt.Errorf("failed to unmute (client %d): %w", index, err)
+		logger.Warn("Failed to unmute the call", "error", err, "index", index)
+		return res, fmt.Errorf("failed to unmute: %w", err)
 	}
+
 	return res, err
 }
 
 // PlayedTime retrieves the elapsed time of the current playback in a voice chat.
-// It returns the elapsed time in seconds and an error if any.
 func (c *TelegramCalls) PlayedTime(chatId int64) (uint64, error) {
 	call, index, err := c.GetGroupAssistant(chatId)
 	if err != nil {
 		return 0, err
 	}
 
-	// TODO: Pass the streamMode.
-	time, err := call.Time(chatId, 0)
+	_time, err := call.Time(chatId, 0)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get played time (client %d): %w", index, err)
+		logger.Warn("Failed to get played time", "error", err, "index", index)
+		return 0, fmt.Errorf("failed to get played time: %w", err)
 	}
-	return time, nil
+
+	return _time, nil
 }
 
 // CpuUsage Get an estimate of the CPU usage of the current process.
@@ -457,13 +367,12 @@ func (c *TelegramCalls) CpuUsage(chatId int64) (float64, error) {
 
 	usage, err := call.CpuUsage()
 	if err != nil {
-		return 0, fmt.Errorf("failed to get cpu usage (client %d): %w", index, err)
+		logger.Warn("Failed to get CPU usage", "error", err, "index", index)
+		return 0, fmt.Errorf("failed to get cpu usage: %w", err)
 	}
 
 	return usage, nil
 }
-
-var urlRegex = regexp.MustCompile(`^https?://`)
 
 // SeekStream jumps to a specific time in the current media stream.
 func (c *TelegramCalls) SeekStream(chatID int64, filePath string, toSeek, duration int, isVideo bool) error {
@@ -493,7 +402,7 @@ func (c *TelegramCalls) ChangeSpeed(chatID int64, speed float64) error {
 
 	playingSong := cache.ChatCache.GetPlayingTrack(chatID)
 	if playingSong == nil {
-		return errors.New("🔇 Nothing is playing")
+		return errors.New("the bot isn't streaming in the video chat")
 	}
 
 	videoPTS := 1 / speed
@@ -523,12 +432,8 @@ func (c *TelegramCalls) RegisterHandlers(client *td.Client) {
 	c.bot = client
 
 	for _, call := range c.uBContext {
-
-		//_, _ = call.App.UpdatesGetState()
 		call.OnStreamEnd(func(chatID int64, streamType ntgcalls.StreamType, device ntgcalls.StreamDevice) {
-			call.App.Logger.Warnf("[TelegramCalls] The stream has ended in chat %d (type=%v, device=%v)", chatID, streamType, device)
 			if streamType == ntgcalls.VideoStream {
-				call.App.Logger.Warnf("Ignoring video stream end for chat %d", chatID)
 				return
 			}
 
@@ -560,14 +465,14 @@ func (c *TelegramCalls) RegisterHandlers(client *td.Client) {
 			return
 		})
 
-		//call.OnFrame(func(chatId int64, mode ntgcalls.StreamMode, device ntgcalls.StreamDevice, frames []ntgcalls.Frame) {
-		//	call.App.Logger.Infof("Received frames for chatId: %d, mode: %v, device: %v", chatId, mode, device)
-		//})
-
-		_, _ = call.App.SendMessage(client.Me.Usernames.EditableUsername, "/start")
-		_, err := call.App.SendMessage(config.Conf.LoggerId, "Userbot started.")
+		_, err := call.App.SendMessage(client.Me.Usernames.EditableUsername, "/start")
 		if err != nil {
-			call.App.Logger.Infof("[TelegramCalls - SendMessage] Failed to send message: %v", err)
+			call.App.Logger.Warnf("failed to start bot: %v", err)
+		}
+
+		_, err = call.App.SendMessage(config.Conf.LoggerId, "Userbot started.")
+		if err != nil {
+			call.App.Logger.Warnf("Failed to send message: %v", err)
 		}
 	}
 }

--- a/src/vc/start.go
+++ b/src/vc/start.go
@@ -1,0 +1,120 @@
+package vc
+
+import (
+	"ashokshau/tgmusic/config"
+	"ashokshau/tgmusic/src/vc/sessions"
+	"ashokshau/tgmusic/src/vc/ubot"
+	"fmt"
+	"log/slog"
+
+	tg "github.com/amarnathcjd/gogram/telegram"
+)
+
+// StartClient initializes a new userbot client and adds it to the pool of available assistants.
+// It authenticates with Telegram using the provided API ID, API hash, and session string.
+// The session type is determined by the configuration (pyrogram, telethon, or gogram).
+func (c *TelegramCalls) StartClient(apiID int32, apiHash, stringSession string) (*ubot.Context, error) {
+	c.mu.Lock()
+	clientIndex := len(c.uBContext)
+	c.mu.Unlock()
+
+	clientName := fmt.Sprintf("client%d", clientIndex)
+
+	var sess *tg.Session
+	var err error
+
+	clientConfig := tg.ClientConfig{
+		AppID:         apiID,
+		AppHash:       apiHash,
+		MemorySession: true,
+		SessionName:   clientName,
+		FloodHandler:  handleFlood,
+		LogLevel:      tg.InfoLevel,
+	}
+
+	switch config.Conf.SessionType {
+	case "telethon":
+		sess, err = sessions.DecodeTelethonSessionString(stringSession)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode telethon session string for %s: %w", clientName, err)
+		}
+		clientConfig.StringSession = sess.Encode()
+	case "pyrogram":
+		sess, err = sessions.DecodePyrogramSessionString(stringSession)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode pyrogram session string for %s: %w", clientName, err)
+		}
+		clientConfig.StringSession = sess.Encode()
+	case "gogram":
+		clientConfig.StringSession = stringSession
+	default:
+		return nil, fmt.Errorf("unsupported session type: %s", config.Conf.SessionType)
+	}
+
+	mtProto, err := tg.NewClient(clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the MTProto client: %w", err)
+	}
+
+	if err = mtProto.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start the client: %w", err)
+	}
+
+	me := mtProto.Me()
+	if me.Bot {
+		_ = mtProto.Stop()
+		return nil, fmt.Errorf("the client %s is a bot", clientName)
+	}
+
+	appConfig, err := mtProto.HelpGetAppConfig(0)
+	if err != nil {
+		logger.Warn("[TelegramCalls] failed to fetch app config", "client", clientName, "error", err)
+	} else {
+		isFreeze := false
+		if cfg, ok := appConfig.(*tg.HelpAppConfigObj); ok {
+			if cfgObj, ok := cfg.Config.(*tg.JsonObject); ok {
+				for _, entry := range cfgObj.Value {
+					if entry != nil && entry.Key == "freeze_since_date" {
+						isFreeze = true
+						break
+					}
+				}
+			}
+		}
+
+		if isFreeze {
+			logger.Warn("[TelegramCalls] The client is frozen and cannot be used for voice calls", "client", clientName, "id", me.ID, "username", me.Username)
+			_ = mtProto.Stop()
+			return nil, nil
+		}
+	}
+
+	call, err := ubot.NewInstance(mtProto)
+	if err != nil {
+		_ = mtProto.Stop()
+		return nil, fmt.Errorf("failed to create the ubot instance: %w", err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.uBContext[clientIndex] = call
+	c.clients[clientIndex] = mtProto
+
+	logger.Info("[TelegramCalls] Client started", "client", clientName, "id", me.ID, "username", me.Username)
+	return call, nil
+}
+
+// StopAllClients gracefully stops all active userbot clients and their associated voice calls.
+func (c *TelegramCalls) StopAllClients() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for _, call := range c.uBContext {
+		call.Close()
+	}
+
+	for idx, client := range c.clients {
+		slog.Info("[TelegramCalls] Stopping the client", "index", idx)
+		_ = client.Stop()
+	}
+}

--- a/src/vc/types.go
+++ b/src/vc/types.go
@@ -10,6 +10,7 @@ package vc
 
 import (
 	"log/slog"
+	"regexp"
 	"sync"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 )
 
 var logger = slog.Default()
+var urlRegex = regexp.MustCompile(`^https?://`)
 
 // TelegramCalls manages the state and operations for voice calls, including userbots and the main bot client.
 type TelegramCalls struct {

--- a/src/vc/userbot.go
+++ b/src/vc/userbot.go
@@ -27,24 +27,29 @@ import (
 func (c *TelegramCalls) joinAssistant(chatID int64, call *ubot.Context, index int) error {
 	status, err := c.checkUserStats(chatID, call, index)
 	if err != nil {
-		return fmt.Errorf("joinAssistant (client %d): check user status: %w", index, err)
+		return fmt.Errorf("joinAssistant (client-%d): check user status: %w", index, err)
 	}
 
 	logger.Info("chat member status", "chat_id", chatID, "status", status, "index", index)
 
 	switch status.(type) {
-	case *td.ChatMemberStatusCreator,
-		*td.ChatMemberStatusAdministrator,
-		*td.ChatMemberStatusMember:
+	case *td.ChatMemberStatusMember, td.ChatMemberStatusCreator, td.ChatMemberStatusAdministrator, td.ChatMemberStatusMember:
 		return nil
 
-	case *td.ChatMemberStatusLeft:
+	case *td.ChatMemberStatusLeft, td.ChatMemberStatusLeft:
 		logger.Info("assistant is not in chat, joining", "chat_id", chatID, "index", index)
 		return c.joinUb(chatID, call, index)
 
-	case *td.ChatMemberStatusBanned, *td.ChatMemberStatusRestricted:
-		_, isBanned := status.(*td.ChatMemberStatusBanned)
-		_, isMuted := status.(*td.ChatMemberStatusRestricted)
+	case *td.ChatMemberStatusBanned, *td.ChatMemberStatusRestricted,
+		td.ChatMemberStatusBanned, td.ChatMemberStatusRestricted:
+		_, isBannedPtr := status.(*td.ChatMemberStatusBanned)
+		_, isBannedVal := status.(td.ChatMemberStatusBanned)
+		isBanned := isBannedPtr || isBannedVal
+
+		_, isMutedPtr := status.(*td.ChatMemberStatusRestricted)
+		_, isMutedVal := status.(td.ChatMemberStatusRestricted)
+		isMuted := isMutedPtr || isMutedVal
+
 		logger.Info("assistant is banned or restricted, attempting recovery",
 			"chat_id", chatID, "banned", isBanned, "muted", isMuted, "index", index)
 
@@ -86,6 +91,7 @@ func (c *TelegramCalls) recoverBannedAssistant(chatID int64, call *ubot.Context,
 		); err != nil {
 			logger.Warn("failed to unban assistant", "ub_id", ubID, "error", err, "index", index)
 		}
+
 		return c.joinUb(chatID, call, index)
 	}
 
@@ -94,64 +100,40 @@ func (c *TelegramCalls) recoverBannedAssistant(chatID int64, call *ubot.Context,
 	return nil
 }
 
-// JoinAssistant attempts to join an assistant to the chat. If the assigned assistant
-// fails, it iterates through all available assistants until one succeeds or all fail.
+// JoinAssistant attempts to join the assigned assistant to the chat.
+// If it fails, it returns an error and removes the assistant from the database.
 func (c *TelegramCalls) JoinAssistant(chatID int64) (*ubot.Context, error) {
-	ctx, cancel := db.Ctx()
-	defer cancel()
+	index, err := c.getClientIndex(chatID)
+	if err != nil {
+		return nil, err
+	}
 
 	c.mu.RLock()
-	totalClients := len(c.uBContext)
+	call, ok := c.uBContext[index]
 	c.mu.RUnlock()
 
-	if totalClients == 0 {
-		return nil, errors.New("no clients are available")
+	if !ok {
+		return nil, fmt.Errorf("client %d not found in context", index)
 	}
 
-	var excludedIndices []int
+	assistantID := call.App.Me().ID
 
-	for i := 0; i < totalClients; i++ {
-		index, err := c.getClientIndex(chatID, excludedIndices)
-		if err != nil {
-			return nil, err
-		}
+	if err = c.joinAssistant(chatID, call, index); err != nil {
+		slog.Info("assistant failed to join chat",
+			"chat_id", chatID, "assistant_id", assistantID, "error", err, "index", index)
 
-		c.mu.RLock()
-		call, ok := c.uBContext[index]
-		c.mu.RUnlock()
+		cacheKey := fmt.Sprintf("%d:%d", chatID, assistantID)
+		c.statusCache.Delete(cacheKey)
+		_ = db.Instance.RemoveAssistant(chatID)
 
-		if !ok {
-			excludedIndices = append(excludedIndices, index)
-			continue
-		}
-
-		assistantID := call.App.Me().ID
-
-		if err = c.joinAssistant(chatID, call, index); err != nil {
-			slog.Info("assistant failed to join chat",
-				"chat_id", chatID, "assistant_id", assistantID, "error", err, "index", index)
-
-			excludedIndices = append(excludedIndices, index)
-
-			cacheKey := fmt.Sprintf("%d:%d", chatID, assistantID)
-			c.statusCache.Delete(cacheKey)
-			_ = db.Instance.RemoveAssistant(ctx, chatID)
-
-			if i == totalClients-1 {
-				return nil, err // all assistants exhausted
-			}
-			continue
-		}
-
-		if err := db.Instance.SetAssistant(ctx, chatID, index); err != nil {
-			slog.Warn("failed to set assistant in database", "chat_id", chatID, "index", index, "error", err)
-		}
-
-		return call, nil
+		return nil, err
 	}
 
-	// Unreachable, but satisfies the compiler :D
-	return nil, errors.New("all assistants failed to join")
+	if err := db.Instance.SetAssistant(chatID, index); err != nil {
+		slog.Warn("failed to set assistant in database", "chat_id", chatID, "index", index, "error", err)
+	}
+
+	return call, nil
 }
 
 // clientIndexFor returns the 0-based index for the given call, or -1 if not found.
@@ -172,7 +154,6 @@ func (c *TelegramCalls) clientIndexFor(call *ubot.Context) int {
 func (c *TelegramCalls) checkUserStats(chatID int64, call *ubot.Context, index int) (td.ChatMemberStatus, error) {
 	userID := call.App.Me().ID
 	cacheKey := fmt.Sprintf("%d:%d", chatID, userID)
-
 	if cached, ok := c.statusCache.Get(cacheKey); ok {
 		return cached, nil
 	}
@@ -181,8 +162,8 @@ func (c *TelegramCalls) checkUserStats(chatID int64, call *ubot.Context, index i
 	if err != nil {
 		errStr := err.Error()
 		if strings.Contains(errStr, "USER_NOT_PARTICIPANT") {
-			c.UpdateMembership(chatID, userID, td.ChatMemberStatusLeft{})
-			return td.ChatMemberStatusLeft{}, nil
+			c.UpdateMembership(chatID, userID, &td.ChatMemberStatusLeft{})
+			return &td.ChatMemberStatusLeft{}, nil
 		}
 
 		return nil, fmt.Errorf("GetChatMember (client %d) chat=%d user=%d: %w", index, chatID, userID, err)
@@ -209,7 +190,7 @@ func (c *TelegramCalls) joinUb(chatID int64, call *ubot.Context, index int) erro
 		return c.handleJoinError(chatID, ub.Me().ID, index, err)
 	}
 
-	c.UpdateMembership(chatID, ub.Me().ID, td.ChatMemberStatusMember{})
+	c.UpdateMembership(chatID, ub.Me().ID, &td.ChatMemberStatusMember{})
 	return nil
 }
 
@@ -223,6 +204,7 @@ func (c *TelegramCalls) resolveInviteLink(chatID int64, cacheKey string) (string
 		chatID, 0, 0, "FallenBeatz",
 		&td.CreateChatInviteLinkOpts{CreatesJoinRequest: false},
 	)
+
 	if err != nil {
 		return "", fmt.Errorf("create invite link for chat %d: %w", chatID, err)
 	}
@@ -239,10 +221,9 @@ func (c *TelegramCalls) resolveInviteLink(chatID int64, cacheKey string) (string
 
 // handleJoinError maps JoinChannel error strings to actionable responses.
 func (c *TelegramCalls) handleJoinError(chatID, userID int64, index int, err error) error {
-	errStr := err.Error()
-
+	errMsg := err.Error()
 	switch {
-	case strings.Contains(errStr, "INVITE_REQUEST_SENT"):
+	case strings.Contains(errMsg, "INVITE_REQUEST_SENT"):
 		time.Sleep(time.Second)
 		if approveErr := c.bot.ProcessChatJoinRequest(
 			chatID, userID,
@@ -253,23 +234,21 @@ func (c *TelegramCalls) handleJoinError(chatID, userID int64, index int, err err
 		}
 		return nil
 
-	case strings.Contains(errStr, "USER_ALREADY_PARTICIPANT"):
-		c.UpdateMembership(chatID, userID, td.ChatMemberStatusMember{})
+	case strings.Contains(errMsg, "USER_ALREADY_PARTICIPANT"):
+		c.UpdateMembership(chatID, userID, &td.ChatMemberStatusMember{})
 		return nil
 
-	case strings.Contains(errStr, "INVITE_HASH_EXPIRED"):
+	case strings.Contains(errMsg, "INVITE_HASH_EXPIRED"):
 		c.inviteCache.Delete(strconv.FormatInt(chatID, 10))
+		c.UpdateMembership(chatID, userID, &td.ChatMemberStatusBanned{})
 		return fmt.Errorf("client %d: assistant (<code>%d</code>) invite link expired or assistant is banned", index, userID)
 
-	case strings.Contains(errStr, "CHANNEL_PRIVATE"):
-		c.UpdateMembership(chatID, userID, td.ChatMemberStatusLeft{})
+	case strings.Contains(errMsg, "CHANNEL_PRIVATE"):
+		c.UpdateMembership(chatID, userID, &td.ChatMemberStatusLeft{})
 		c.inviteCache.Delete(strconv.FormatInt(chatID, 10))
 		return fmt.Errorf("client %d: assistant (<code>%d</code>) is banned from this group", index, userID)
-
-	case strings.Contains(errStr, "FROZEN_METHOD_INVALID"):
-		return fmt.Errorf("client %d: assistant (<code>%d</code>) is frozen and cannot join via invite link\n\nPlease report in support chat ASAF.", index, userID)
 	}
 
 	logger.Warn("unhandled JoinChannel error", "error", err, "index", index)
-	return fmt.Errorf("(client %d, <code>%d</code>): assistant failed to join: %w", index, userID, err)
+	return fmt.Errorf("(client%d, <code>%d</code>): assistant failed to join: %w", index, userID, err)
 }


### PR DESCRIPTION
Centralize and standardize context/timeouts and API method signatures across the codebase. Key changes:

- Introduced db.ctx() helper and shifted many Database methods to create their own context (removed ctx parameters from many db methods). Added timeouts for long operations (InitDatabase, GetAllUsers/GetAllChats) and cache behavior updates.
- Renamed and unexported downloader-related types and methods (ApiData->apiData, DirectLink->directLink, Download->download, New*/Get*/Process/etc. -> new*/get*/Process) and updated callers accordingly; HTTP client sendRequest now manages its own context and timeouts. downloadFile/DownloadCachedTrack and other download flows adjusted.
- Buttons: SettingsKeyboard now accepts cmdDelete and language and updates button layout/labels.
- main: adjusted slog attribute keys and added AutoRetry and DatabaseDirectory to gotdbot client config; small init ordering tweak.
- Various DB modules updated to use db.ctx(), remove redundant context imports, and to update cache invalidation logic.
- Minor docs and README link fix.