### PR TITLE
Refresh cookies hourly and guard CookiesPath access

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,7 @@ func LoadConfig() error {
 		if err := os.MkdirAll(cookiesDr, 0750); err != nil {
 			return fmt.Errorf("failed to create temp dir: %w", err)
 		}
-		go saveAllCookies(Conf.cookiesUrl)
+		go startCookieRefresher(Conf.cookiesUrl)
 	}
 
 	return nil

--- a/config/save_cookies.go
+++ b/config/save_cookies.go
@@ -16,9 +16,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
-const cookiesDr = "src/cookies"
+const (
+	cookiesDr        = "src/cookies"
+	cookieFetchTimeout = 30 * time.Second
+	cookieRefreshInterval = time.Hour
+)
+
+var cookieHTTPClient = &http.Client{Timeout: cookieFetchTimeout}
 
 // fetchContent downloads content from Pastebin or Batbin.
 // It takes a URL as input.
@@ -36,7 +43,7 @@ func fetchContent(url string) (string, error) {
 		rawURL = url
 	}
 
-	resp, err := http.Get(rawURL)
+	resp, err := cookieHTTPClient.Get(rawURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to GET %s: %w", rawURL, err)
 	}
@@ -56,7 +63,7 @@ func fetchContent(url string) (string, error) {
 	return string(body), nil
 }
 
-// saveContent saves content to a file in /tmp and returns the file path.
+// saveContent saves content to a file in the cookies directory and returns the file path.
 // It takes a URL and content as input.
 // It returns the file path and an error if any.
 func saveContent(url, content string) (string, error) {
@@ -84,22 +91,41 @@ func saveContent(url, content string) (string, error) {
 	return filePath, nil
 }
 
-// saveAllCookies downloads all URLs and stores paths in Conf.CookiesPath.
+// refreshCookies downloads all URLs and atomically replaces Conf.CookiesPath.
 // It takes a slice of URLs as input.
-func saveAllCookies(urls []string) {
+func refreshCookies(urls []string) {
+	paths := make([]string, 0, len(urls))
 	for _, url := range urls {
 		content, err := fetchContent(url)
 		if err != nil {
-			slog.Info("Error fetching cookies from", "arg1", url, "error", err)
+			slog.Info("Error fetching cookies from", "url", url, "error", err)
 			continue
 		}
 
 		path, err := saveContent(url, content)
 		if err != nil {
-			slog.Info("Error saving cookies for", "arg1", url, "error", err)
+			slog.Info("Error saving cookies for", "url", url, "error", err)
 			continue
 		}
 
-		Conf.CookiesPath = append(Conf.CookiesPath, path)
+		paths = append(paths, path)
+	}
+
+	Conf.SetCookiesPath(paths)
+	slog.Info("Refreshed cookies", "count", len(paths), "total_urls", len(urls))
+}
+
+// startCookieRefresher runs an initial fetch and then refreshes on a fixed interval.
+// It exits when there are no URLs configured.
+func startCookieRefresher(urls []string) {
+	if len(urls) == 0 {
+		return
+	}
+	refreshCookies(urls)
+
+	ticker := time.NewTicker(cookieRefreshInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		refreshCookies(urls)
 	}
 }

--- a/config/types.go
+++ b/config/types.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // BotConfig holds the configuration for the bot.
@@ -37,9 +38,29 @@ type BotConfig struct {
 	SupportGroup      string   // SupportGroup is the Telegram group link.
 	SupportChannel    string   // SupportChannel is the Telegram channel link.
 	DEVS              []int64  // DEVS is a list of developer user IDs.
-	CookiesPath       []string // CookiesPath is a list of paths to cookies files.
+	CookiesPath       []string // CookiesPath is a list of paths to cookies files. Use GetCookiesPath/SetCookiesPath for concurrent access.
 	cookiesUrl        []string // cookiesUrl is a list of URLs to cookies files.
+	cookiesMu         sync.RWMutex
 	Port              string
+}
+
+// GetCookiesPath returns a snapshot of the current cookie file paths.
+func (c *BotConfig) GetCookiesPath() []string {
+	c.cookiesMu.RLock()
+	defer c.cookiesMu.RUnlock()
+	if len(c.CookiesPath) == 0 {
+		return nil
+	}
+	out := make([]string, len(c.CookiesPath))
+	copy(out, c.CookiesPath)
+	return out
+}
+
+// SetCookiesPath atomically replaces the cookie file paths.
+func (c *BotConfig) SetCookiesPath(paths []string) {
+	c.cookiesMu.Lock()
+	c.CookiesPath = paths
+	c.cookiesMu.Unlock()
 }
 
 // getSessionStrings gets session strings from environment variable with prefix

--- a/src/core/dl/youtube.go
+++ b/src/core/dl/youtube.go
@@ -241,7 +241,7 @@ func (y *YouTubeData) downloadWithYtDlp(ctx context.Context, videoID string, vid
 
 // getCookieFile retrieves the path to a cookie file from the configured list.
 func (y *YouTubeData) getCookieFile() string {
-	cookiesPath := config.Conf.CookiesPath
+	cookiesPath := config.Conf.GetCookiesPath()
 	if len(cookiesPath) == 0 {
 		return ""
 	}


### PR DESCRIPTION
## Why

Cookie URLs were only fetched once at startup, so when YouTube cookies expired the bot kept using the stale files until a restart (yt-dlp returning `Sign in to confirm you're not a bot`). Cookie paths were also appended to `Conf.CookiesPath` from a background goroutine without any locking against concurrent reads from `getCookieFile`.

## Changes

- Add `sync.RWMutex` + `GetCookiesPath` / `SetCookiesPath` accessors on `BotConfig`.
- Wrap `fetchContent` in an `http.Client` with a 30s timeout (was a bare `http.Get` that could hang indefinitely).
- Build the new path list locally and swap it atomically per refresh — no more accumulation across refreshes.
- Initial fetch then refresh every hour via `time.Ticker` (new `startCookieRefresher`).
- `YouTubeData.getCookieFile` reads paths through the locked accessor.

## Test plan

- [ ] `go build ./...`
- [ ] Run bot, confirm initial cookie fetch logs `Refreshed cookies count=N`.
- [ ] Update pastebin content, wait <1h, confirm new cookies are picked up without restart and yt-dlp stops hitting the bot-check error.

## Summary by Sourcery

Refresh cookie download handling to support periodic updates and thread-safe access across the bot.

New Features:
- Introduce hourly cookie refresh via a background ticker-driven refresher.

Bug Fixes:
- Ensure expired YouTube cookie files are refreshed without requiring a bot restart.
- Prevent data races when accessing cookie path configuration from multiple goroutines.

Enhancements:
- Use an HTTP client with a bounded timeout for cookie URL fetches.
- Atomically replace cookie file path lists instead of accumulating paths across refreshes.
- Add concurrency-safe accessors for cookie file paths and use them from YouTube download logic.